### PR TITLE
Fix a few issues with the examples

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.0)
 project (katranserver-proj)
+set (CMAKE_CXX_STANDARD 14)
 
 # thrift cmake macro
 find_program(THRIFT1 thrift1)

--- a/example/client/KatranSimpleClient.cpp
+++ b/example/client/KatranSimpleClient.cpp
@@ -39,12 +39,14 @@ using apache::thrift::async::TAsyncSocket;
 namespace {
 constexpr uint64_t IPPROTO_TCP = 6;
 constexpr uint64_t IPPROTO_UDP = 17;
+constexpr uint64_t DEFAULT_FLAG = 0;
 constexpr uint64_t NO_SPORT = 1;
 constexpr uint64_t NO_LRU = 2;
 constexpr uint64_t QUIC_VIP = 4;
 constexpr uint64_t DPORT_HASH = 8;
 
 const std::map<std::string, uint64_t> flagTranslationTable = {
+    {"", DEFAULT_FLAG},
     {"NO_SPORT", NO_SPORT},
     {"NO_LRU", NO_LRU},
     {"QUIC_VIP", QUIC_VIP},

--- a/example_grpc/CMakeLists.txt
+++ b/example_grpc/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(katran_grpc)
+set (CMAKE_CXX_STANDARD 14)
 
 find_library(PROTOBUF libprotobuf.a protobuf)
 find_library(GRPC libgrpc.a grpc)


### PR DESCRIPTION
This fixes a compile error for the examples (on Ubuntu 16.04 at least), and
teaches the SimpleClient how to handle empty flag (-f) values.

I ran into these issues while trying out Katran and thought I'd submit a fix :)