### PR TITLE
Get katran listen addr from input flags

### DIFF
--- a/example_grpc/goclient/src/katranc/katranc/katranc.go
+++ b/example_grpc/goclient/src/katranc/katranc/katranc.go
@@ -63,10 +63,10 @@ type KatranClient struct {
 	client lb_katran.KatranServiceClient
 }
 
-func (kc *KatranClient) Init() {
+func (kc *KatranClient) Init(serverAddr string) {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithInsecure())
-	conn, err := grpc.Dial("127.0.0.1:50051", opts...)
+	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {
 		log.Fatalf("Can't connect to local katran server! err is %v\n", err)
 	}

--- a/example_grpc/goclient/src/katranc/main/main.go
+++ b/example_grpc/goclient/src/katranc/main/main.go
@@ -62,6 +62,8 @@ var (
 	listQuicMapping = flag.Bool("list_qm", false, "List current quic's mappings")
 	delQuicMapping  = flag.Bool("del_qm", false,
 		"Delete instead of adding specified quic mapping")
+	katranServer  = flag.String("server", "127.0.0.1:50051",
+		"Katran server listen address")
 )
 
 func main() {
@@ -76,7 +78,7 @@ func main() {
 		proto = IPPROTO_UDP
 	}
 	var kc katranc.KatranClient
-	kc.Init()
+	kc.Init(*katranServer)
 	if *changeMac != "" {
 		kc.ChangeMac(*changeMac)
 	} else if *listMac {

--- a/example_grpc/katran_server.cpp
+++ b/example_grpc/katran_server.cpp
@@ -36,7 +36,7 @@
 using grpc::Server;
 using grpc::ServerBuilder;
 
-DEFINE_int32(port, 10889, "Service port");
+DEFINE_string(server, "0.0.0.0:50051", "Service server:port");
 DEFINE_string(intf, "eth0", "main interface");
 DEFINE_string(hc_intf, "", "interface for healthchecking");
 DEFINE_string(ipip_intf, "ipip0", "ipip (v4) encap interface");
@@ -84,7 +84,7 @@ void RunServer(
     katran::KatranConfig& config,
     int32_t delay,
     std::shared_ptr<folly::EventBase> evb) {
-  std::string server_address("0.0.0.0:50051");
+  std::string server_address(FLAGS_server);
   lb::katran::KatranGrpcService service(config);
 
   ServerBuilder builder;


### PR DESCRIPTION
backward compatible (because of default values)
remove unused port flag in `katran_server.cpp` file