### PR TITLE
[katran]: adding initial support for userspace counters

### DIFF
--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -429,6 +429,7 @@ bool KatranLb::changeMac(const std::vector<uint8_t> newMac) {
         &key,
         &ctlValues_[kMacAddrPos].mac);
     if (res != 0) {
+      lbStats_.bpfFailedCalls++;
       VLOG(4) << "can't add new mac address";
       return false;
     }
@@ -623,6 +624,7 @@ bool KatranLb::modifyRealsForVip(
       key = vip_num * config_.chRingSize + pos.pos;
       res = bpfAdapter_.bpfUpdateMap(ch_fd, &key, &pos.real);
       if (res != 0) {
+        lbStats_.bpfFailedCalls++;
         LOG(INFO) << "can't update ch ring";
       }
     }
@@ -860,6 +862,7 @@ bool KatranLb::modifyLpmMap(
           bpfAdapter_.getMapFdByName(mapName), &key_v4, value);
       if (res != 0) {
         LOG(INFO) << "can't add new element into " << mapName;
+        lbStats_.bpfFailedCalls++;
         return false;
       }
     } else {
@@ -867,6 +870,7 @@ bool KatranLb::modifyLpmMap(
           bpfAdapter_.getMapFdByName(mapName), &key_v4);
       if (res != 0) {
         LOG(INFO) << "can't delete element from " << mapName;
+        lbStats_.bpfFailedCalls++;
         return false;
       }
     }
@@ -881,6 +885,7 @@ bool KatranLb::modifyLpmMap(
           bpfAdapter_.getMapFdByName(mapName), &key_v6, value);
       if (res != 0) {
         LOG(INFO) << "can't add new element into " << mapName;
+        lbStats_.bpfFailedCalls++;
         return false;
       }
     } else {
@@ -888,6 +893,7 @@ bool KatranLb::modifyLpmMap(
           bpfAdapter_.getMapFdByName(mapName), &key_v6);
       if (res != 0) {
         LOG(INFO) << "can't delete element from " << mapName;
+        lbStats_.bpfFailedCalls++;
         return false;
       }
     }
@@ -956,6 +962,7 @@ bool KatranLb::modifyDecapDst(
         bpfAdapter_.getMapFdByName("decap_dst"), &addr, &flags);
     if (res != 0) {
       LOG(ERROR) << "error while adding dst for inline decap " << dst;
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   } else {
@@ -963,6 +970,7 @@ bool KatranLb::modifyDecapDst(
         bpfAdapter_.getMapFdByName("decap_dst"), &addr);
     if (res != 0) {
       LOG(ERROR) << "error while deleting dst for inline decap " << dst;
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   }
@@ -1020,6 +1028,7 @@ void KatranLb::modifyQuicRealsMapping(
       res = bpfAdapter_.bpfUpdateMap(quic_mapping_fd, &id, &rnum);
       if (res != 0) {
         LOG(ERROR) << "can't update quic mapping";
+        lbStats_.bpfFailedCalls++;
       }
     }
   }
@@ -1091,6 +1100,8 @@ lb_stats KatranLb::getLbStats(uint32_t position, const std::string& map) {
         sum_stat.v1 += stat.v1;
         sum_stat.v2 += stat.v2;
       }
+    } else {
+      lbStats_.bpfFailedCalls++;
     }
   }
   return sum_stat;
@@ -1130,6 +1141,7 @@ bool KatranLb::addHealthcheckerDst(
         bpfAdapter_.getMapFdByName("hc_reals_map"), &key, &addr);
     if (res != 0) {
       LOG(INFO) << "can't add new real for healthchecking";
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   }
@@ -1155,6 +1167,7 @@ bool KatranLb::delHealthcheckerDst(const uint32_t somark) {
         bpfAdapter_.getMapFdByName("hc_reals_map"), &key);
     if (res) {
       LOG(INFO) << "can't remove hc w/ somark: " << key;
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   }
@@ -1186,6 +1199,7 @@ bool KatranLb::updateVipMap(
         bpfAdapter_.getMapFdByName("vip_map"), &vip_def, meta);
     if (res != 0) {
       LOG(INFO) << "can't add new element into vip_map";
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   } else {
@@ -1193,6 +1207,7 @@ bool KatranLb::updateVipMap(
         bpfAdapter_.getMapFdByName("vip_map"), &vip_def);
     if (res != 0) {
       LOG(INFO) << "can't delete element from vip_map";
+      lbStats_.bpfFailedCalls++;
       return false;
     }
   }
@@ -1205,6 +1220,7 @@ bool KatranLb::updateRealsMap(const std::string& real, uint32_t num) {
       bpfAdapter_.getMapFdByName("reals"), &num, &real_addr);
   if (res != 0) {
     LOG(INFO) << "can't add new real";
+    lbStats_.bpfFailedCalls++;
     return false;
   } else {
     return true;

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -477,6 +477,16 @@ class KatranLb {
    */
   KatranMonitorStats getKatranMonitorStats();
 
+  /**
+   * @return KatranLbStats generic stats about userspace part of katran
+   *
+   * helper function which helps to introspect internals of katran's
+   * userspace counterpart
+   */
+  KatranLbStats getKatranLbStats() {
+    return lbStats_;
+  }
+
  private:
   /**
    * update vipmap(add or remove vip) in forwarding plane
@@ -680,6 +690,11 @@ class KatranLb {
    * vector of LRU maps descriptors;
    */
   std::vector<int> lruMapsFd_;
+
+  /**
+   * userspace library stats
+   */
+  KatranLbStats lbStats_;
 };
 
 } // namespace katran

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -189,6 +189,17 @@ struct KatranMonitorStats {
 };
 
 /**
+ * @param uint64_t bpfFailedCalls number of failed syscalls
+ *
+ * generic userspace related stats to track internals of katran library
+ * such as number of failed bpf syscalls (could happens if we are trying to add
+ * to many vips etc)
+ */
+struct KatranLbStats {
+  uint64_t bpfFailedCalls{0};
+};
+
+/**
  * @param srcRouting flag which indicates that source based routing feature has
  * been enabled/compiled in bpf forwarding plane
  * @param inlineDecap flag which indicates that inline decapsulation feature has

--- a/katran/lib/testing/katran_tester.cpp
+++ b/katran/lib/testing/katran_tester.cpp
@@ -246,6 +246,11 @@ void testLbCounters(katran::KatranLb& lb) {
       LOG(INFO) << "Expected to be incorrect w/ non default build flags";
     }
   }
+  auto lb_stats = lb.getKatranLbStats();
+  if (lb_stats.bpfFailedCalls != 0) {
+    VLOG(2) << "failed bpf calls: " << lb_stats.bpfFailedCalls;
+    LOG(INFO) << "incorrect stats about katran library internals";
+  }
   LOG(INFO) << "Testing of counters is complete";
   return;
 }


### PR DESCRIPTION
as stated. right now if we failed bpf syscall (e.g. have tried to add more vips (or reals)
than there are spots in predefined array) we would get just a line in the log file,
which is easy to miss. lets store counters of failed bpf calls for such situations
(as well as total number of bpf calls). also we would bump this counters
only if program wont be terminated (so e.g. in init code we check
that expected maps exists. it make no sense to bump error counter
right before we would throw an exception)

also in this diff i've added additional counter related test into katran_tester which tests this new code path