### PR TITLE
changing internal representation of ip addresses  for reals from string to binary

### DIFF
--- a/katran/lib/IpHelpers.cpp
+++ b/katran/lib/IpHelpers.cpp
@@ -16,7 +16,6 @@
 
 #include "IpHelpers.h"
 
-#include <folly/IPAddress.h>
 #include <folly/lang/Bits.h>
 #include <stdexcept>
 
@@ -25,24 +24,27 @@ namespace katran {
 constexpr int Uint32_bytes = 4;
 constexpr uint8_t V6DADDR = 1;
 
-struct beaddr IpHelpers::parseAddrToBe(
-    const std::string& addr,
-    bool bigendian) {
-  auto ipaddr = folly::IPAddress(addr);
+struct beaddr IpHelpers::parseAddrToBe(const std::string &addr,
+                                       bool bigendian) {
+  return parseAddrToBe(folly::IPAddress(addr), bigendian);
+}
+
+struct beaddr IpHelpers::parseAddrToBe(const folly::IPAddress &addr,
+                                       bool bigendian) {
   struct beaddr translated_addr = {};
-  if (ipaddr.isV4()) {
+  if (addr.isV4()) {
     translated_addr.flags = 0;
     if (bigendian) {
-      translated_addr.daddr = ipaddr.asV4().toLong();
+      translated_addr.daddr = addr.asV4().toLong();
     } else {
-      translated_addr.daddr = ipaddr.asV4().toLongHBO();
+      translated_addr.daddr = addr.asV4().toLongHBO();
     }
   } else {
     for (int partition = 0; partition < 4; partition++) {
       // bytes() return a ptr to char* array
       // so we are doing some ptr arithmetics here
       uint32_t addr_part =
-          *(uint32_t*)(ipaddr.bytes() + Uint32_bytes * partition);
+          *(uint32_t *)(addr.bytes() + Uint32_bytes * partition);
       if (bigendian) {
         translated_addr.v6daddr[partition] = addr_part;
       } else {
@@ -54,7 +56,11 @@ struct beaddr IpHelpers::parseAddrToBe(
   return translated_addr;
 };
 
-struct beaddr IpHelpers::parseAddrToInt(const std::string& addr) {
+struct beaddr IpHelpers::parseAddrToInt(const std::string &addr) {
+  return parseAddrToBe(addr, false);
+};
+
+struct beaddr IpHelpers::parseAddrToInt(const folly::IPAddress &addr) {
   return parseAddrToBe(addr, false);
 };
 

--- a/katran/lib/IpHelpers.h
+++ b/katran/lib/IpHelpers.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/IPAddress.h>
 #include <string>
 
 namespace katran {
@@ -33,7 +34,7 @@ struct beaddr {
 };
 
 class IpHelpers {
- public:
+public:
   /**
    * @param const string addr address to translate
    * @return struct beaddr representation of given address
@@ -42,10 +43,13 @@ class IpHelpers {
    * of beaddr structure. this function could throw, if given string is not
    * an ip address.
    */
-  static struct beaddr parseAddrToBe(
-      const std::string& addr,
-      bool bigendian = true);
-  static struct beaddr parseAddrToInt(const std::string& addr);
+  static struct beaddr parseAddrToBe(const std::string &addr,
+                                     bool bigendian = true);
+  static struct beaddr parseAddrToInt(const std::string &addr);
+
+  static struct beaddr parseAddrToBe(const folly::IPAddress &addr,
+                                     bool bigendian = true);
+  static struct beaddr parseAddrToInt(const folly::IPAddress &addr);
 };
 
 } // namespace katran

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -328,9 +328,7 @@ class KatranLb {
    *
    * helper function to get internal index to real's ip address mapping.
    */
-  const std::unordered_map<uint32_t, std::string>& getNumToRealMap() {
-    return numToReals_;
-  }
+  const std::unordered_map<uint32_t, std::string> getNumToRealMap();
 
   /**
    * @return uint32_t number of src to dst mappings
@@ -499,7 +497,7 @@ class KatranLb {
   /**
    * update(add or remove) reals map in forwarding plane
    */
-  bool updateRealsMap(const std::string& real, uint32_t num);
+  bool updateRealsMap(const folly::IPAddress& real, uint32_t num);
 
   /**
    * helper function to get stats from counter on specified possition
@@ -510,12 +508,12 @@ class KatranLb {
    * helper function to decrease real's ref count and delete it from
    * internal dicts if rec count became zero
    */
-  void decreaseRefCountForReal(const std::string& real);
+  void decreaseRefCountForReal(const folly::IPAddress& real);
 
   /**
    * helper function to add new real or increase ref count for existing one
    */
-  uint32_t increaseRefCountForReal(const std::string& real);
+  uint32_t increaseRefCountForReal(const folly::IPAddress& real);
 
   /**
    * helper function to do initial sanity checking right after bpf programs
@@ -593,7 +591,7 @@ class KatranLb {
    */
   bool modifyDecapDst(
       ModifyAction action,
-      const std::string& dst,
+      const folly::IPAddress& dst,
       const uint32_t flags = 0);
 
   /**
@@ -627,15 +625,15 @@ class KatranLb {
   /**
    * dict of so_mark to real mapping; for healthchecking
    */
-  std::unordered_map<uint32_t, std::string> hcReals_;
+  std::unordered_map<uint32_t, folly::IPAddress> hcReals_;
 
-  std::unordered_map<std::string, RealMeta> reals_;
-  std::unordered_map<std::string, uint32_t> quicMapping_;
+  std::unordered_map<folly::IPAddress, RealMeta> reals_;
+  std::unordered_map<folly::IPAddress, uint32_t> quicMapping_;
   /**
    * for reverse real's lookup. get real by num.
    * used when we are going to delete vip and coresponding reals.
    */
-  std::unordered_map<uint32_t, std::string> numToReals_;
+  std::unordered_map<uint32_t, folly::IPAddress> numToReals_;
 
   std::unordered_map<VipKey, Vip, VipKeyHasher> vips_;
 
@@ -647,7 +645,7 @@ class KatranLb {
   /**
    * set of destantions, which are used for inline decapsulation.
    */
-  std::unordered_set<std::string> decapDsts_;
+  std::unordered_set<folly::IPAddress> decapDsts_;
 
   /**
    * flag which indicates if katran is working in "standalone" mode or not.

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -190,6 +190,7 @@ struct KatranMonitorStats {
 
 /**
  * @param uint64_t bpfFailedCalls number of failed syscalls
+ * @param uint64_t addrValidationFailed times provided ipaddress was invalid
  *
  * generic userspace related stats to track internals of katran library
  * such as number of failed bpf syscalls (could happens if we are trying to add
@@ -197,6 +198,7 @@ struct KatranMonitorStats {
  */
 struct KatranLbStats {
   uint64_t bpfFailedCalls{0};
+  uint64_t addrValidationFailed{0};
 };
 
 /**

--- a/katran/lib/testing/katran_tester.cpp
+++ b/katran/lib/testing/katran_tester.cpp
@@ -249,8 +249,16 @@ void testLbCounters(katran::KatranLb& lb) {
   auto lb_stats = lb.getKatranLbStats();
   if (lb_stats.bpfFailedCalls != 0) {
     VLOG(2) << "failed bpf calls: " << lb_stats.bpfFailedCalls;
-    LOG(INFO) << "incorrect stats about katran library internals";
+    LOG(INFO) << "incorrect stats about katran library internals: "
+              << "number of failed bpf syscalls is non zero";
   }
+  if (lb_stats.addrValidationFailed != 0) {
+    VLOG(2) << "failed ip address validations: " 
+            << lb_stats.addrValidationFailed;
+    LOG(INFO) << "incorrect stats about katran library internals: "
+              << "number of failed ip address validations is non zero";
+  }
+
   LOG(INFO) << "Testing of counters is complete";
   return;
 }

--- a/katran/lib/tests/KatranLbTest.cpp
+++ b/katran/lib/tests/KatranLbTest.cpp
@@ -293,6 +293,8 @@ TEST_F(KatranLbTest, invalidAddressHandling) {
   // adding incorrect hc dst
   res = lb.addHealthcheckerDst(1, "bbb");
   ASSERT_FALSE(res);
+  auto stats = lb.getKatranLbStats();
+  ASSERT_EQ(stats.addrValidationFailed, 3);
 };
 
 TEST_F(KatranLbTest, addInvalidSrcRoutingRule) {


### PR DESCRIPTION
as stated. currently katran is exposed to capslock like issues.
e.g. we could add same v6 address multiple times and that would pass all the tests
(e.g. real fc00::1 fc00:0::1 fc00:0:0::1 etc).
current behavior wont break anything, as in forwarding plane everything
is in binary anyway, but we would consume more resources than needed.
(e.g. real for regular vip could in any format, but quic's real
in exploded)

tested by:
- it compiles (c)
- unittests
- katran_tester

---
1. this is taking care only about real's addresses, struct VipKey still has
vip's address as a string. so it would take more work to modify that as well
(as VipKey is a public API. current changes wont break anything external
as API's return values have not changed. only internal's ones)

2. if i run clang-format on KatranLb.h/cpp it makes some changes
in unrelated lines (most likely either format from 8.0 has some modifications
or it was not run on that files for a while). what would you prefer?
would you accept diff w/ some unrelated changed caused by clang format?