### PR TITLE
Re-sync with internal repository

### DIFF
--- a/build/deps/github_hashes/facebook/folly-rev.txt
+++ b/build/deps/github_hashes/facebook/folly-rev.txt
@@ -1,1 +1,1 @@
-Subproject commit 9f73ab954fd52b08f9dfff54440389ce72ae3fa3
+Subproject commit 66270d4e7bd12c079d2ff93d02e82d2d41ce509c

--- a/katran/OSS_SYNC
+++ b/katran/OSS_SYNC
@@ -1,9 +1,0 @@
-guide on how to sync katran to oss.
-
-today it is done manually (T_T. at least script is
-on it's way so this could be done just by running shell. mb one day we would
-use proper FB tool for that). you need to sync
-only lib folder to facebookincubator/katran github project.
-(https://github.com/facebookincubator/katran/tree/master/katran)
-after sync make sure that all internal files (TARGETS) are not copied.
-


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.