### PR TITLE
[katran]: allow to specify should unlimited memlock be used or not

### DIFF
--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -42,7 +42,7 @@ constexpr uint32_t kMaxQuicId = 65535; // 2^16-1
 
 KatranLb::KatranLb(const KatranConfig& config)
     : config_(config),
-      bpfAdapter_(!config.testing),
+      bpfAdapter_(config.memlockUnlimited),
       ctlValues_(kCtlMapSize),
       standalone_(true),
       forwardingCores_(config.forwardingCores),

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -132,6 +132,7 @@ struct KatranMonitorConfig {
  * @param uint32_t maxDecapDst maximum number of destinations for inline decap
  * @param std::string hcInterface interface where we want to attach hc bpf prog
  * @param KatranMonitorConfig monitorConfig for katran introspection
+ * @param memlockUnlimited should katran set memlock to unlimited by default
  *
  * note about rootMapPath and rootMapPos:
  * katran has two modes of operation.
@@ -174,6 +175,7 @@ struct KatranConfig {
   std::string hcInterface = kDefaultHcInterface;
   uint32_t xdpAttachFlags = kNoFlags;
   struct KatranMonitorConfig monitorConfig;
+  bool memlockUnlimited = true;
 };
 
 /**

--- a/katran/lib/tests/KatranLbTest.cpp
+++ b/katran/lib/tests/KatranLbTest.cpp
@@ -42,7 +42,11 @@ class KatranLbTest : public ::testing::Test {
                         {},
                         {},
                         10,
-                        4}){};
+                        4,
+                        "eth0",
+                        0,
+                        {},
+                        false}){};
 
   void SetUp() override {
     v1.address = "fc01::1";


### PR DESCRIPTION
by default katran today requesting (during startup) unlimited amount
of locked memory. this is suboptimal for environments where
container managment system wants to enforce this number as well.
in this diff i'm adding a flag in katran's config, which would
allow us to bypas setting memlock limit to unlimited, and hence would
rely on external (to katran) managing system to do so

this diff wont change defautl behavior - by default we still would
try to set limit to RLIM_UNLIMITED

Tested By:
unittests + katran_tester