### PR TITLE
[bpf]: fixing compilation wornings

### DIFF
--- a/katran/lib/bpf/handle_icmp.h
+++ b/katran/lib/bpf/handle_icmp.h
@@ -118,8 +118,8 @@ static inline int send_icmp4_too_big(struct xdp_md *xdp) {
   if (bpf_xdp_adjust_head(xdp, 0 - headroom)) {
     return XDP_DROP;
   }
-  void *data = xdp->data;
-  void *data_end = xdp->data_end;
+  void *data = (void *)(long)xdp->data;
+  void *data_end = (void *)(long)xdp->data_end;
   if (data + (ICMP_TOOBIG_SIZE + headroom) > data_end) {
     return XDP_DROP;
   }
@@ -163,8 +163,8 @@ static inline int send_icmp6_too_big(struct xdp_md *xdp) {
   if (bpf_xdp_adjust_head(xdp, 0 - headroom)) {
     return XDP_DROP;
   }
-  void *data = xdp->data;
-  void *data_end = xdp->data_end;
+  void *data = (void *)(long)xdp->data;
+  void *data_end = (void *)(long)xdp->data_end;
   if (data + (ICMP6_TOOBIG_SIZE + headroom) > data_end) {
     return XDP_DROP;
   }


### PR DESCRIPTION
currently during compilation clang issuing annoying warnings in build system
like this: https://gist.github.com/tehnerd/3e5f615335577145260c9cda13ebaebb
fixing em by explicitly casting things

Tested By:
running katran_tester to make sure that we did not break anything
also  this is nop from bpf instructions point of view