### PR TITLE
[katran]: adding gating logic for introspection

### DIFF
--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -826,8 +826,32 @@ const std::unordered_map<uint32_t, std::string> KatranLb::getNumToRealMap() {
   return reals;
 }
 
+bool KatranLb::changeKatranMonitorForwardingState(KatranMonitorState state) {
+    uint32_t key = kIntrospectionGkPos;
+    struct ctl_value value;
+    switch (state) {
+      case KatranMonitorState::ENABLED:
+        value.value = 1;
+        break;
+      case KatranMonitorState::DISABLED:
+        value.value = 0;
+        break;
+    }
+    auto res = bpfAdapter_.bpfUpdateMap(
+      bpfAdapter_.getMapFdByName("ctl_array"), &key, &value);
+    if (res != 0) {
+      LOG(INFO) << "can't change state of introspection forwarding plane";
+      lbStats_.bpfFailedCalls++;
+      return false;
+    } 
+    return true;
+}
+
 bool KatranLb::stopKatranMonitor() {
   if (!features_.introspection) {
+    return false;
+  }
+  if (!changeKatranMonitorForwardingState(KatranMonitorState::DISABLED)) {
     return false;
   }
   monitor_->stopMonitor();
@@ -836,6 +860,9 @@ bool KatranLb::stopKatranMonitor() {
 
 bool KatranLb::restartKatranMonitor(uint32_t limit) {
   if (!features_.introspection) {
+    return false;
+  }
+  if (!changeKatranMonitorForwardingState(KatranMonitorState::ENABLED)) {
     return false;
   }
   monitor_->restartMonitor(limit);

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -45,6 +45,7 @@ constexpr int kIpv4TunPos = 1;
 constexpr int kIpv6TunPos = 2;
 constexpr int kMainIntfPos = 3;
 constexpr int kHcIntfPos = 4;
+constexpr int kIntrospectionGkPos = 5;
 
 /**
  * constants are from balancer_consts.h
@@ -63,6 +64,18 @@ constexpr int kFallbackLruSize = 1024;
 constexpr int kMapNoFlags = 0;
 constexpr int kMapNumaNode = 4;
 constexpr int kNoNuma = -1;
+
+namespace {
+/**
+ * state of katran monitor forwarding. if it is disabled - forwarding
+ * plane would never send anything to userspace through perfpipe
+ */
+enum class KatranMonitorState {
+  DISABLED,
+  ENABLED,
+};
+
+}
 
 /**
  * This class implements all routines to interact with katran load balancer
@@ -604,6 +617,11 @@ class KatranLb {
       ModifyAction action,
       const folly::IPAddress& dst,
       const uint32_t flags = 0);
+
+  /**
+   * helper function to change state of katran monitor's forwarding
+   */
+  bool changeKatranMonitorForwardingState(KatranMonitorState state);
 
   /**
    * main configurations of katran

--- a/katran/lib/bpf/balancer_helpers.h
+++ b/katran/lib/bpf/balancer_helpers.h
@@ -24,6 +24,7 @@
 
 #include "balancer_consts.h"
 #include "balancer_structs.h"
+#include "balancer_maps.h"
 #include "bpf.h"
 #include "bpf_helpers.h"
 
@@ -96,13 +97,19 @@ static inline void ipv6_csum(void *data_start, int data_size,
   *csum = csum_fold_helper(*csum);
 }
 
+
 /**
  * helper to print blob of data into perf pipe
  */
 __attribute__((__always_inline__))
 static inline void submit_event(struct xdp_md *ctx, void *map,
                                 __u32 event_id, void *data, __u32 size) {
-
+  struct ctl_value *gk;
+  __u32 introspection_gk_pos = 5;
+  gk = bpf_map_lookup_elem(&ctl_array, &introspection_gk_pos);
+  if (!gk || gk->value == 0) {
+    return;
+  }
   struct event_metadata md = {};
   __u64 flags = BPF_F_CURRENT_CPU;
   md.event = event_id;


### PR DESCRIPTION
this diff is adding default katran's introspection behavior by adding gating
logic in forwarding plane.

before this diff, if katran is compiled w/ introspection enabled,
it would unconditionally send data to userspace for triggered events.
even if userspace does not want to receive any data (e.g. limit set to 0
etc). the issue is that if somehow we have high rate of events
(e.g. synflood w/ lru trashing) - single core in userspace (which is responsible for reading
data from perfpipe and dropping it (as limit is set to 0)) would be pegged.
hence by default it is dangerous to run introspection (and today strategy is to deploy
katran w/ introspection enabled when needed; which could be suboptimal,
as it would require restart and issue could go away).

proposed diff adds gatekeeper in bpf code, which would prevent sending data to
userspace in a first place if it is not requested. the cost of this GK is
+20 bpf instructions and +1 array lookup. which is not that much and would allow
to have introspection code deployed unconditionally and enable dumping when needed
w/o any restart.

as w/ original introspection code this new logic works only if katran
was compiled w/ KATRAN_INTROSPECTION define/flag

Tested by:
katran_tester. made sure that if gk value is set to 1 (by default)
we still have pcap files generated w/ packets which have triggered LRU miss.
and if it set to 0 - these files are empty