### PR TITLE
[katran][bpf]: dedicated helpers to create v4/v6 headers

### DIFF
--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -196,6 +196,11 @@
 #define IPIP_V6_PREFIX3 0
 #endif
 
+// default tos/tclass value
+#ifndef DEFAULT_TOS
+#define DEFAULT_TOS 0
+#endif
+
 // initial value for jhash hashing function, used to pick up a real server
 #ifndef INIT_JHASH_SEED
 #define INIT_JHASH_SEED CH_RINGS_SIZE

--- a/katran/lib/bpf/pckt_encap.h
+++ b/katran/lib/bpf/pckt_encap.h
@@ -36,6 +36,38 @@
 #include "pckt_parsing.h"
 
 __attribute__((__always_inline__))
+static inline void create_v4_hdr(struct iphdr *iph, __u32 saddr, __u32 daddr,
+                                 __u16 pkt_bytes, __u8 proto) {
+  __u64 csum = 0;
+  iph->version = 4;
+  iph->ihl = 5;
+  iph->frag_off = 0;
+  iph->protocol = proto;
+  iph->check = 0;
+  iph->tos = DEFAULT_TOS;
+  iph->tot_len = bpf_htons(pkt_bytes + sizeof(struct iphdr));
+  iph->daddr = daddr;
+  iph->saddr = saddr;
+  iph->ttl = DEFAULT_TTL;
+  ipv4_csum_inline(iph, &csum);
+  iph->check = csum;
+}
+
+__attribute__((__always_inline__))
+static inline void create_v6_hdr(struct ipv6hdr *ip6h, __u32 *saddr,
+                                 __u32 *daddr, __u16 payload_len, __u8 proto) {
+  ip6h->version = 6;
+  ip6h->priority = DEFAULT_TOS;
+  memset(ip6h->flow_lbl, 0 , sizeof(ip6h->flow_lbl));
+  ip6h->nexthdr = proto;
+  ip6h->payload_len = bpf_htons(payload_len);
+  ip6h->hop_limit = DEFAULT_TTL;
+  memcpy(ip6h->saddr.s6_addr32, saddr, 16);
+  memcpy(ip6h->daddr.s6_addr32, daddr, 16);
+}
+
+
+__attribute__((__always_inline__))
 static inline bool encap_v6(struct xdp_md *xdp, struct ctl_value *cval,
                             bool is_ipv6, struct packet_description *pckt,
                             struct real_definition *dst, __u32 pkt_bytes) {
@@ -44,7 +76,10 @@ static inline bool encap_v6(struct xdp_md *xdp, struct ctl_value *cval,
   struct ipv6hdr *ip6h;
   struct eth_hdr *new_eth;
   struct eth_hdr *old_eth;
+  __u16 payload_len;
   __u32 ip_suffix;
+  __u32 saddr[4];
+  __u8 proto;
   // ip(6)ip6 encap
   if (bpf_xdp_adjust_head(xdp, 0 - (int)sizeof(struct ipv6hdr))) {
     return false;
@@ -62,28 +97,24 @@ static inline bool encap_v6(struct xdp_md *xdp, struct ctl_value *cval,
   memcpy(new_eth->eth_dest, cval->mac, 6);
   memcpy(new_eth->eth_source, old_eth->eth_dest, 6);
   new_eth->eth_proto = BE_ETH_P_IPV6;
-  ip6h->version = 6;
-  // If needed, this could be changed to map from src pkt
-  // (instead of 0 currently), or to anything else we may want.
-  ip6h->priority = 0;
-  memset(ip6h->flow_lbl, 0 , sizeof(ip6h->flow_lbl));
 
   if (is_ipv6) {
-    ip6h->nexthdr = IPPROTO_IPV6;
+    proto = IPPROTO_IPV6;
     ip_suffix = pckt->flow.srcv6[3] ^ pckt->flow.port16[0];
-    ip6h->payload_len = bpf_htons(pkt_bytes + sizeof(struct ipv6hdr));
+    payload_len = pkt_bytes + sizeof(struct ipv6hdr);
   } else {
-    ip6h->nexthdr = IPPROTO_IPIP;
+    proto = IPPROTO_IPIP;
     ip_suffix = pckt->flow.src ^ pckt->flow.port16[0];
-    ip6h->payload_len = bpf_htons(pkt_bytes);
+    payload_len = pkt_bytes;
   }
-  ip6h->hop_limit = DEFAULT_TTL;
 
-  ip6h->saddr.s6_addr32[0] = IPIP_V6_PREFIX1;
-  ip6h->saddr.s6_addr32[1] = IPIP_V6_PREFIX2;
-  ip6h->saddr.s6_addr32[2] = IPIP_V6_PREFIX3;
-  ip6h->saddr.s6_addr32[3] = ip_suffix;
-  memcpy(ip6h->daddr.s6_addr32, dst->dstv6, 16);
+  saddr[0] = IPIP_V6_PREFIX1;
+  saddr[1] = IPIP_V6_PREFIX2;
+  saddr[2] = IPIP_V6_PREFIX3;
+  saddr[3] = ip_suffix;
+
+  create_v6_hdr(ip6h, saddr, dst->dstv6, payload_len, proto);
+
   return true;
 }
 
@@ -119,21 +150,12 @@ static inline bool encap_v4(struct xdp_md *xdp, struct ctl_value *cval,
   memcpy(new_eth->eth_source, old_eth->eth_dest, 6);
   new_eth->eth_proto = BE_ETH_P_IP;
 
-  iph->version = 4;
-  iph->ihl = 5;
-  iph->frag_off = 0;
-  iph->protocol = IPPROTO_IPIP;
-  iph->check = 0;
-  // as w/ v6 we could configure tos to something else
-  iph->tos = 0;
-  iph->tot_len = bpf_htons(pkt_bytes + sizeof(struct iphdr));
-  iph->daddr = dst->dst;
-
-  iph->saddr = ((0xFFFF0000 & ip_suffix) | IPIP_V4_PREFIX);
-  iph->ttl = DEFAULT_TTL;
-
-  ipv4_csum_inline(iph, &csum);
-  iph->check = csum;
+  create_v4_hdr(
+    iph,
+    ((0xFFFF0000 & ip_suffix) | IPIP_V4_PREFIX),
+    dst->dst,
+    pkt_bytes,
+    IPPROTO_IPIP);
 
   return true;
 }


### PR DESCRIPTION
reworking the way we generate v4/v6 headers:
making separate helpers, which are agnostic to usecase
(e.g. could be reused anywhere else, as they dont have anything xdp specific).
this would make easier to create other types of encapsulations (e.g. GUE
as it could be reused there))

some nice benefits is that default build has -14 bpf instructions
(1684 vs 1670. seems like clang shuffled things around a bit and
optimized registers usage).

Tested by:
katran_tester. passing all the tests