### PR TITLE
[katran]: adding iobuf writer

### DIFF
--- a/katran/lib/CMakeLists.txt
+++ b/katran/lib/CMakeLists.txt
@@ -80,10 +80,12 @@ target_include_directories(
 add_library(pcapwriter STATIC
     ByteRangeWriter.cpp
     FileWriter.cpp
+    IOBufWriter.cpp
     PcapMsg.cpp
     PcapMsgMeta.cpp
     PcapWriter.cpp
     ByteRangeWriter.h
+    IOBufWriter.h
     DataWriter.h
     FileWriter.h
     PcapMsg.h

--- a/katran/lib/IOBufWriter.cpp
+++ b/katran/lib/IOBufWriter.cpp
@@ -1,0 +1,38 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "katran/lib/IOBufWriter.h"
+#include <cstring>
+
+namespace katran {
+
+IOBufWriter::IOBufWriter(folly::IOBuf* iobuf)
+    : iobuf_(iobuf) {}
+
+void IOBufWriter::writeData(const void* ptr, std::size_t size) {
+  ::memcpy(static_cast<void*>(iobuf_->writableTail()), ptr, size);
+  iobuf_->append(size);
+}
+
+bool IOBufWriter::available(std::size_t amount) {
+  return iobuf_->tailroom() >= amount;
+}
+
+bool IOBufWriter::restart() {
+  iobuf_->clear();
+  return true;
+}
+
+} // namespace katran

--- a/katran/lib/IOBufWriter.h
+++ b/katran/lib/IOBufWriter.h
@@ -1,0 +1,47 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <folly/io/IOBuf.h>
+
+#include "katran/lib/DataWriter.h"
+
+namespace katran {
+
+/**
+ * IOBufWriter is used to write pcap-data into IOBuf.
+ */
+class IOBufWriter : public DataWriter {
+ public:
+  /**
+   * @param unique_ptr<IOBuf> iobuf for packets to written into
+   */
+  explicit IOBufWriter(folly::IOBuf* iobuf);
+
+  void writeData(const void* ptr, std::size_t size) override;
+
+  bool available(std::size_t amount) override;
+
+  bool restart() override;
+
+  bool stop() override {return true;}
+
+ private:
+  folly::IOBuf* iobuf_;
+};
+
+} // namespace katran

--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -858,6 +858,14 @@ bool KatranLb::stopKatranMonitor() {
   return true;
 }
 
+std::unique_ptr<folly::IOBuf> KatranLb::getKatranMonitorEventBuffer(int event) {
+  if (!features_.introspection) {
+    return nullptr;
+  }
+  return monitor_->getEventBuffer(event);
+}
+
+
 bool KatranLb::restartKatranMonitor(uint32_t limit) {
   if (!features_.introspection) {
     return false;
@@ -877,6 +885,7 @@ KatranMonitorStats KatranLb::getKatranMonitorStats() {
   auto writer_stats = monitor_->getWriterStats();
   stats.limit = writer_stats.limit;
   stats.amount = writer_stats.amount;
+  stats.bufferExceedCount = writer_stats.bufferExceedCount;
   return stats;
 }
 

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -482,6 +482,18 @@ class KatranLb {
   bool restartKatranMonitor(uint32_t limit);
 
   /**
+   * @param int event monitoring event it. see balancer_consts.h
+   * @return unique_ptr<IOBuf> on success or nullptr otherwise
+   *
+   * getKatranMonitorEventBuffer return iobuf which contains all the packets
+   * for specified event. if event number was not defined or
+   * PcapStorageFormat was not set to IOBUF nullptr would be returned.
+   * This function is not thread safe. underlying IOBuf, when accessed while
+   * monitoring is still running, could point to partially written packet
+   */
+  std::unique_ptr<folly::IOBuf> getKatranMonitorEventBuffer(int event);
+
+  /**
    * @return KatranMonitorStats stats from katran monitor
    *
    * if katran introspection is enabled: return stats from monitor. such as

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -86,6 +86,14 @@ enum class AddressType {
 };
 
 /**
+ * types of monitoring
+ */
+enum class PcapStorageFormat {
+  FILE,
+  IOBUF,
+};
+
+/**
  * @param uint32_t nCpus number of cpus
  * @param uint32_t pages number of pages for even pipe shared memory
  * @param int mapFd descriptor of event pipe map
@@ -107,6 +115,8 @@ struct KatranMonitorConfig {
   uint32_t snapLen{kDefaultMonitorSnapLen};
   uint32_t maxEvents{kDefaultMonitorMaxEvents};
   std::string path{"/tmp/katran_pcap"};
+  PcapStorageFormat storage{PcapStorageFormat::FILE};
+  uint32_t bufferSize{0};
 };
 
 /**
@@ -188,6 +198,7 @@ struct KatranConfig {
 struct KatranMonitorStats {
   uint32_t limit{0};
   uint32_t amount{0};
+  uint32_t bufferExceedCount{0};
 };
 
 /**

--- a/katran/lib/KatranMonitor.h
+++ b/katran/lib/KatranMonitor.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <thread>
 #include <vector>
+#include <folly/io/IOBuf.h>
 #include <folly/MPMCQueue.h>
 
 #include "katran/lib/KatranLbStructs.h"
@@ -50,6 +51,8 @@ class KatranMonitor {
   void restartMonitor(uint32_t limit);
 
   PcapWriterStats getWriterStats();
+  
+  std::unique_ptr<folly::IOBuf> getEventBuffer(int event);
 
  private:
   /**
@@ -77,6 +80,12 @@ class KatranMonitor {
    * thread which runs pcap writer
    */
   std::thread writerThread_;
+  
+  /**
+   * vector of iobufs where we store packets if IOBUF storage
+   * is being used
+   */
+  std::vector<std::unique_ptr<folly::IOBuf>> buffers_;
 };
 
 } // namespace katran

--- a/katran/lib/PcapWriter.cpp
+++ b/katran/lib/PcapWriter.cpp
@@ -81,13 +81,13 @@ bool PcapWriter::writePcapHeader(uint32_t writerId) {
     LOG(ERROR) << "no writer w/ specified ID: " << writerId;
     return false;
   }
-  if (!dataWriters_[writerId]->available(sizeof(struct pcap_hdr_s))) {
-    LOG(ERROR) << "DataWriter failed to write a header. Too few space.";
-    return false;
-  }
   if (headerExists_[writerId]) {
     VLOG(4) << "header already exists";
     return true;
+  }
+  if (!dataWriters_[writerId]->available(sizeof(struct pcap_hdr_s))) {
+    LOG(ERROR) << "DataWriter failed to write a header. Not enough space.";
+    return false;
   }
   struct pcap_hdr_s hdr {
     .magic_number = kPcapWriterMagic, .version_major = kVersionMajor,
@@ -116,7 +116,7 @@ void PcapWriter::run(std::shared_ptr<folly::MPMCQueue<PcapMsg>> queue) {
     }
     if (!dataWriters_[kDefaultWriter]->available(
             msg.getCapturedLen() + sizeof(pcaprec_hdr_s))) {
-      LOG(INFO) << "DataWriter is full.";
+      ++bufferExceedCount_;
       break;
     }
     writePacket(msg, kDefaultWriter);
@@ -129,6 +129,7 @@ PcapWriterStats PcapWriter::getStats() {
   Guard lock(cntrLock_);
   stats.limit = packetLimit_;
   stats.amount = packetAmount_;
+  stats.bufferExceedCount = bufferExceedCount_;
   return stats;
 }
 
@@ -183,6 +184,7 @@ void PcapWriter::runMulti(
     msg.getPcapMsg().trim(snaplen);
     if (!dataWriters_[msg.getEventId()]->available(
             msg.getPcapMsg().getCapturedLen() + sizeof(pcaprec_hdr_s))) {
+      ++bufferExceedCount_;
       continue;
     }
     writePacket(msg.getPcapMsg(), msg.getEventId());

--- a/katran/lib/PcapWriter.h
+++ b/katran/lib/PcapWriter.h
@@ -27,6 +27,7 @@
 struct PcapWriterStats {
   uint32_t limit{0};
   uint32_t amount{0};
+  uint32_t bufferExceedCount{0};
 };
 
 namespace katran {
@@ -153,6 +154,12 @@ class PcapWriter {
    * Max number of packets that can be written in a single batch
    */
   uint32_t packetLimit_{0};
+
+  /**
+   * Number of bufferExceedCount events: when writer does not have enough
+   * space to write packet
+   */
+  uint32_t bufferExceedCount_{0};
 
   /**
    * Max number of bytes to be stored.


### PR DESCRIPTION
today KatranMonitor storing packets on a disk in pcap format.
sometime it is more usefull to store em in memory and allow for remote client
get em (e.g. through thrift/grpc call). in this diff i'm adding such ability
by implementing IOBufWriter

Tested By:
modified katran_tester. making sure that iobuf contains proper pcap
data (by writing this data in a file in tester, and then reading
w/ tcpdump)