### PR TITLE
[katran]: support pass traffic for reals flagged with PASS_ONLY

### DIFF
--- a/example/client/KatranSimpleClient.cpp
+++ b/example/client/KatranSimpleClient.cpp
@@ -44,10 +44,11 @@ constexpr uint64_t NO_SPORT = 1;
 constexpr uint64_t NO_LRU = 2;
 constexpr uint64_t QUIC_VIP = 4;
 constexpr uint64_t DPORT_HASH = 8;
+constexpr uint64_t PASS_ONLY = 16;
 
 const std::map<std::string, uint64_t> flagTranslationTable = {
     {"", DEFAULT_FLAG},     {"NO_SPORT", NO_SPORT},     {"NO_LRU", NO_LRU},
-    {"QUIC_VIP", QUIC_VIP}, {"DPORT_HASH", DPORT_HASH},
+    {"QUIC_VIP", QUIC_VIP}, {"DPORT_HASH", DPORT_HASH}, {"PASS_ONLY", PASS_ONLY},
 };
 }; // namespace
 
@@ -190,6 +191,9 @@ std::string KatranSimpleClient::parseFlags(uint64_t flags) {
   }
   if ((flags & DPORT_HASH) > 0) {
     flagsStr += " DPORT_HASH ";
+  }
+  if ((flags & PASS_ONLY) > 0) {
+    flagsStr += " PASS_ONLY ";
   }
   return flagsStr;
 }

--- a/example_grpc/goclient/src/katranc/katranc/katranc.go
+++ b/example_grpc/goclient/src/katranc/katranc/katranc.go
@@ -36,6 +36,7 @@ const (
 	NO_LRU      = 2
 	QUIC_VIP    = 4
 	DPORT_HASH  = 8
+	PASS_ONLY   = 16
 )
 
 const (
@@ -50,6 +51,7 @@ var (
 		"NO_LRU":     NO_LRU,
 		"QUIC_VIP":   QUIC_VIP,
 		"DPORT_HASH": DPORT_HASH,
+		"PASS_ONLY":  PASS_ONLY,
 	}
 )
 

--- a/example_grpc/goclient/src/katranc/katranc/katranc.go
+++ b/example_grpc/goclient/src/katranc/katranc/katranc.go
@@ -280,6 +280,9 @@ func parseFlags(flags uint64) string {
 	if flags&uint64(DPORT_HASH) > 0 {
 		flags_str += " DPORT_HASH "
 	}
+	if flags&uint64(PASS_ONLY) > 0 {
+    		flags_str += " PASS_ONLY "
+    	}
 	return flags_str
 }
 

--- a/example_grpc/goclient/src/katranc/main/main.go
+++ b/example_grpc/goclient/src/katranc/main/main.go
@@ -46,7 +46,7 @@ var (
 	showIcmpStats = flag.Bool("icmp", false, "Show ICMP 'packet too big' related stats")
 	listServices  = flag.Bool("l", false, "List configured services")
 	changeFlags   = flag.String("f", "",
-		"change flags. Possible values: NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH")
+		"change flags. Possible values: NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH, PASS_ONLY")
 	unsetFlags = flag.Bool("unset", false, "Unset specified flags")
 	newHc      = flag.String("new_hc", "", "Address of new backend to healtcheck")
 	somark     = flag.Uint64("somark", 0, "Socket mark to specified backend")

--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -101,6 +101,8 @@
 #define F_HASH_DPORT_ONLY (1 << 3)
 // check if src based routing should be used
 #define F_SRC_ROUTING (1 << 4)
+// dont encapsulate packet and just return XDP_PASS (e.g. when vip and real are the same machine)
+#define F_PASS_ONLY (1 << 5)
 // packet_description flags:
 // the description has been created from icmp msg
 #define F_ICMP (1 << 0)

--- a/katran/lib/bpf/balancer_kern.c
+++ b/katran/lib/bpf/balancer_kern.c
@@ -505,6 +505,10 @@ static inline int process_packet(void *data, __u64 off, void *data_end,
     return XDP_DROP;
   }
 
+  if(dst->flags & F_PASS_ONLY){
+    return XDP_PASS;
+  }
+
   if (dst->flags & F_IPV6) {
     if(!encap_v6(xdp, cval, is_ipv6, &pckt, dst, pkt_bytes)) {
       return XDP_DROP;


### PR DESCRIPTION
Pass packets when the real server (destination) flagged as PASS_ONLY. Usable for a situation that the VIP and the REAL are the same. It will reduce response time by preventing congestion on switch/router devices.