### PR TITLE
[katran]: flags for reals

### DIFF
--- a/example/KatranSimpleServiceHandler.cpp
+++ b/example/KatranSimpleServiceHandler.cpp
@@ -39,6 +39,7 @@ using Guard = std::lock_guard<std::mutex>;
   ::katran::NewReal nr;
   nr.address = real.address;
   nr.weight = real.weight;
+  nr.flags = real.flags;
   return nr;
 }
 
@@ -201,6 +202,7 @@ void KatranSimpleServiceHandler::getRealsForVip(
   for (auto& real : reals) {
     r.address = real.address;
     r.weight = real.weight;
+    r.flags = real.flags;
     _return.push_back(r);
   }
   return;

--- a/example/client/KatranSimpleClient.h
+++ b/example/client/KatranSimpleClient.h
@@ -55,7 +55,7 @@ public:
 
   void updateServerForVip(const std::string &vipAddr, int proto,
                           const std::string &realAddr, uint64_t weight,
-                          bool del);
+                          uint64_t realFlags, bool del);
 
   void modifyQuicMappings(const std::string &mapping, bool del);
 
@@ -92,11 +92,13 @@ public:
 private:
   Vip parseToVip(const std::string &address, uint32_t protocol);
 
-  Real parseToReal(const std::string &address, uint32_t weight);
+  Real parseToReal(const std::string &address, uint32_t weight, uint64_t flags);
 
   QuicReal parseToQuicReal(const std::string &mapping);
 
   std::string parseFlags(uint64_t flags);
+
+ std::string parseRealFlags(uint64_t flags);
 
   // factory method to create KatranServiceClient instance
   std::unique_ptr<KatranServiceAsyncClient>

--- a/example/client/Main.cpp
+++ b/example/client/Main.cpp
@@ -45,7 +45,8 @@ DEFINE_bool(l, false, "List configured services");
 DEFINE_bool(C, false, "Clear all configs");
 DEFINE_string(
     f, "",
-    "change flags. Possible values: NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH");
+    "change flags. Possible values: "
+    "NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH, XDP_PASS_ONLY");
 DEFINE_bool(unset, false, "Unset specified flags");
 DEFINE_string(new_hc, "", "Address of new backend to healthcheck");
 DEFINE_uint64(somark, 0, "Socket mark to specified backend");
@@ -112,10 +113,10 @@ int main(int argc, char **argv) {
     client.addOrModifyService(service, changeFlags, proto, true, !FLAGS_unset);
   } else if (addServerFlag || editServerFlag) {
     client.updateServerForVip(service, proto, realServerFlag, realWeightFlag,
-                              false);
+                              changeFlags, false);
   } else if (delServerFlag) {
     client.updateServerForVip(service, proto, realServerFlag, realWeightFlag,
-                              true);
+                              changeFlags, true);
   } else if (FLAGS_del_qm) {
     if (FLAGS_quic_mapping == "") {
       LOG(FATAL) << "quic_mapping is not specified.";

--- a/example/katran.thrift
+++ b/example/katran.thrift
@@ -42,6 +42,7 @@ struct VipMeta {
 struct Real {
   1: string address,
   2: i32 weight,
+  3: i64 flags,
 }
 
 struct QuicReal {

--- a/example_grpc/KatranGrpcService.cpp
+++ b/example_grpc/KatranGrpcService.cpp
@@ -43,6 +43,7 @@ using Guard = std::lock_guard<std::mutex>;
   ::katran::NewReal nr;
   nr.address = real.address();
   nr.weight = real.weight();
+  nr.flags = real.flags();
   return nr;
 }
 
@@ -240,6 +241,7 @@ Status KatranGrpcService::getRealsForVip(ServerContext *context,
   for (auto &real : reals) {
     r.set_address(real.address);
     r.set_weight(real.weight);
+    r.set_flags(real.flags);
     auto rr = response->add_reals();
     *rr = r;
   }

--- a/example_grpc/goclient/src/katranc/main/main.go
+++ b/example_grpc/goclient/src/katranc/main/main.go
@@ -46,7 +46,8 @@ var (
 	showIcmpStats = flag.Bool("icmp", false, "Show ICMP 'packet too big' related stats")
 	listServices  = flag.Bool("l", false, "List configured services")
 	changeFlags   = flag.String("f", "",
-		"change flags. Possible values: NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH")
+		"change flags. Possible values: " +
+		"NO_SPORT, NO_LRU, QUIC_VIP, DPORT_HASH, XDP_PASS_ONLY")
 	unsetFlags = flag.Bool("unset", false, "Unset specified flags")
 	newHc      = flag.String("new_hc", "", "Address of new backend to healtcheck")
 	somark     = flag.Uint64("somark", 0, "Socket mark to specified backend")
@@ -93,9 +94,11 @@ func main() {
 	} else if *editService {
 		kc.AddOrModifyService(service, *changeFlags, proto, true, !*unsetFlags)
 	} else if *addServer || *editServer {
-		kc.UpdateServerForVip(service, proto, *realServer, *realWeight, false)
+		kc.UpdateServerForVip(service, proto, *realServer, *realWeight,
+		*changeFlags, false)
 	} else if *delServer {
-		kc.UpdateServerForVip(service, proto, *realServer, *realWeight, true)
+		kc.UpdateServerForVip(service, proto, *realServer, *realWeight,
+		 *changeFlags, true)
 	} else if *delQuicMapping {
 		kc.ModifyQuicMappings(*quicMapping, true)
 	} else if *quicMapping != "" {

--- a/example_grpc/protos/katran.proto
+++ b/example_grpc/protos/katran.proto
@@ -46,6 +46,7 @@ message VipMeta {
 message Real {
   string address = 1;
   int32 weight = 2;
+  int64 flags = 3;
 }
 
 message QuicReal {

--- a/katran/lib/BalancerStructs.h
+++ b/katran/lib/BalancerStructs.h
@@ -53,6 +53,16 @@ struct vip_meta {
   uint32_t vip_num;
 };
 
+// real's definition for lookup
+struct real_definition {
+  union {
+    __be32 dst;
+    __be32 dstv6[4];
+  };
+  __u8 flags;
+  __u64 real_flags;  //real flags
+};
+
 // generic struct for statistics counters
 struct lb_stats {
   uint64_t v1;

--- a/katran/lib/CHHelpers.h
+++ b/katran/lib/CHHelpers.h
@@ -33,6 +33,7 @@ struct Endpoint {
   uint32_t num;
   uint32_t weight;
   uint64_t hash;
+  uint64_t flags;
 };
 
 /**

--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -611,7 +611,7 @@ bool KatranLb::modifyRealsForVip(
           continue;
         }
         if (!config_.testing) {
-          updateRealsMap(real, real.flags, rnum);
+          updateRealsMap(raddr, real.flags, rnum);
         }
         ureal.updatedReal.num = rnum;
       }
@@ -1278,7 +1278,7 @@ bool KatranLb::updateVipMap(
   return true;
 }
 
-bool KatranLb::updateRealsMap(const folly::IPAddress &real, uint64_t flags, uint32_t num) {
+bool KatranLb::updateRealsMap(const folly::IPAddress &real, const uint64_t flags, uint32_t num) {
   auto real_addr = IpHelpers::parseAddrToBe(real);
   real_definition real_def = {};
   real_def.flags = real_addr.flags;

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -521,7 +521,8 @@ class KatranLb {
   /**
    * update(add or remove) reals map in forwarding plane
    */
-  bool updateRealsMap(const folly::IPAddress& real, uint32_t num);
+  bool updateRealsMap(const folly::IPAddress& real,
+                      uint64_t flags, uint32_t num);
 
   /**
    * helper function to get stats from counter on specified possition

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -522,7 +522,7 @@ class KatranLb {
    * update(add or remove) reals map in forwarding plane
    */
   bool updateRealsMap(const folly::IPAddress& real,
-                      uint64_t flags, uint32_t num);
+                      const uint64_t flags, uint32_t num);
 
   /**
    * helper function to get stats from counter on specified possition

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -66,6 +66,7 @@ struct RealMeta {
 struct NewReal {
   std::string address;
   uint32_t weight;
+  uint64_t flags;
 };
 
 /**

--- a/katran/lib/Vip.cpp
+++ b/katran/lib/Vip.cpp
@@ -85,6 +85,7 @@ std::vector<Endpoint> Vip::getRealsAndWeight() {
     endpoint.num = r.first;
     endpoint.weight = r.second.weight;
     endpoint.hash = r.second.hash;
+    endpoint.flags = r.second.realFlags;
     endpoints[i++] = endpoint;
   }
   return endpoints;
@@ -104,6 +105,7 @@ std::vector<Endpoint> Vip::getEndpoints(std::vector<UpdateReal>& ureals) {
       if (cur_weight != ureal.updatedReal.weight) {
         reals_[ureal.updatedReal.num].weight = ureal.updatedReal.weight;
         reals_[ureal.updatedReal.num].hash = ureal.updatedReal.hash;
+        reals_[ureal.updatedReal.num].realFlags = ureal.updatedReal.flags;
         reals_changed = true;
       }
     }
@@ -116,6 +118,7 @@ std::vector<Endpoint> Vip::getEndpoints(std::vector<UpdateReal>& ureals) {
         endpoint.num = real.first;
         endpoint.weight = real.second.weight;
         endpoint.hash = real.second.hash;
+        endpoint.flags = real.second.realFlags;
         endpoints.push_back(endpoint);
       };
     }

--- a/katran/lib/Vip.h
+++ b/katran/lib/Vip.h
@@ -45,11 +45,12 @@ struct UpdateReal {
 
 /**
  * struct which is used by Vip class to store real's related metadata
- * such as real's weight and hash
+ * such as real's weight and hash and flags
  */
 struct VipRealMeta {
   uint32_t weight;
   uint64_t hash;
+  uint64_t realFlags;
 };
 
 /**

--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -109,6 +109,11 @@
 // packet was decapsulated inline
 #define F_INLINE_DECAP (1 << 2)
 
+// flags for reals
+// prevent ipip encap and return xdp_pass
+// (useful when vip and real are the same machine)
+#define F_XDP_PASS_ONLY (1 << 0)
+
 // ttl for outer ipip packet
 #ifndef DEFAULT_TTL
 #define DEFAULT_TTL 64

--- a/katran/lib/bpf/balancer_kern.c
+++ b/katran/lib/bpf/balancer_kern.c
@@ -505,6 +505,10 @@ static inline int process_packet(void *data, __u64 off, void *data_end,
     return XDP_DROP;
   }
 
+  if(dst->real_flags & F_XDP_PASS_ONLY) {
+    return XDP_PASS;
+  }
+
   if (dst->flags & F_IPV6) {
     if(!encap_v6(xdp, cval, is_ipv6, &pckt, dst, pkt_bytes)) {
       return XDP_DROP;

--- a/katran/lib/bpf/balancer_structs.h
+++ b/katran/lib/bpf/balancer_structs.h
@@ -85,6 +85,7 @@ struct real_definition {
     __be32 dstv6[4];
   };
   __u8 flags;
+  __u64 r_flags;
 };
 
 // per vip statistics

--- a/katran/lib/bpf/balancer_structs.h
+++ b/katran/lib/bpf/balancer_structs.h
@@ -85,7 +85,7 @@ struct real_definition {
     __be32 dstv6[4];
   };
   __u8 flags;
-  __u64 r_flags;
+  __u64 real_flags;
 };
 
 // per vip statistics

--- a/katran/lib/tests/KatranLbTest.cpp
+++ b/katran/lib/tests/KatranLbTest.cpp
@@ -53,7 +53,7 @@ class KatranLbTest : public ::testing::Test {
     v1.port = 443;
     v1.proto = 6;
     v2.address = "fc01::2";
-    v1.port = 443;
+    v2.port = 443;
     v2.proto = 6;
     r1.address = "192.168.1.1";
     r1.weight = 10;
@@ -70,11 +70,13 @@ class KatranLbTest : public ::testing::Test {
         k = (i * 256 + j);
         if (k <= 4096) {
           real1.address = folly::sformat("10.0.{}.{}", i, j);
+          real1.flags = 1;
           newReals1.push_back(real1);
           qreal1.address = real1.address;
           qreal1.id = k;
           qReals1.push_back(qreal1);
           real2.address = folly::sformat("10.1.{}.{}", i, j);
+          real2.flags = 2;
           newReals2.push_back(real2);
           qreal2.address = real2.address;
           qreal2.id = k;
@@ -190,6 +192,8 @@ TEST_F(KatranLbTest, testUpdateRealsHelper) {
   ASSERT_TRUE(lb.modifyRealsForVip(action, newReals2, v2));
   // v1 has all reals;
   ASSERT_EQ(lb.getRealsForVip(v1).size(), 4096);
+  // check flags
+  ASSERT_EQ(lb.getRealsForVip(v1)[0].flags, 1);
   // v2 has 0 reals because when we were trying to add new ones there was no
   // more space for new reals.
   ASSERT_EQ(lb.getRealsForVip(v2).size(), 0);
@@ -205,6 +209,8 @@ TEST_F(KatranLbTest, testUpdateRealsHelper) {
   ASSERT_TRUE(lb.modifyRealsForVip(action, newReals2, v2));
   ASSERT_EQ(lb.getRealsForVip(v2).size(), 4096);
   ASSERT_EQ(lb.getNumToRealMap().size(), 4096);
+  // check flags
+  ASSERT_EQ(lb.getRealsForVip(v2)[0].flags, 2);
 };
 
 TEST_F(KatranLbTest, testUpdateQuicRealsHelper) {


### PR DESCRIPTION
Add support for real's flags. Also, add XDP_PASS_ONLY flag for reals in order to prevent encapsulation  (ipip) and just return XDP_PASS. This feature is useful when vip and real are the same machine.