### PR TITLE
[katran]: minor fixes in build scripts

### DIFF
--- a/build_bpf_modules_opensource.sh
+++ b/build_bpf_modules_opensource.sh
@@ -41,7 +41,7 @@ while getopts ":hb:s:m" arg; do
     s)
       SRC_DIR="${OPTARG}"
       ;;
-    h | *) # Display help.
+    h) # Display help.
       usage
       exit 0
       ;;
@@ -51,13 +51,13 @@ done
 # Validate required parameters
 if [ -z "${BUILD_DIR-}" ] ; then
   echo -e "[ INFO ] BUILD_DIR is not set. So setting it as default to $(pwd)"
-  BUILD_DIR=$(pwd)
+  BUILD_DIR="$(pwd)/_build/"
 fi
 
 # Validate required parameters
 if [ -z "${SRC_DIR-}" ] ; then
-  echo -e "[ INFO ] SRC_DIR is not set. So setting it as default to $(pwd)/.. "
-  SRC_DIR="${BUILD_DIR}"/..
+  echo -e "[ INFO ] SRC_DIR is not set. So setting it as default to $(pwd) "
+  SRC_DIR="$(pwd)"
 fi
 
 

--- a/build_katran.sh
+++ b/build_katran.sh
@@ -16,7 +16,7 @@
  # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 set -xeo pipefail
-NCPUS=$(grep -c processor < /proc/cpuinfo)
+NCPUS=$(nproc)
 # default to 4 threads for a reasonable build speed (e.g in travis)
 if (( NCPUS < 4 )); then
   NCPUS=4


### PR DESCRIPTION
currently build_bpf_module_opensource wont build anything w/ default flags
(and w/o absolute path for -b) fixing it so open source version
for modules could be build w/o using any flags
(afair internaly different script was used; so lets optimize this one
for opensource usecase)

Tested By:
running script and then running tester to make sure that everything is fine