### PR TITLE
[katran]: add GUE encap

### DIFF
--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -639,6 +639,12 @@ class KatranLb {
    * helper function to change state of katran monitor's forwarding
    */
   bool changeKatranMonitorForwardingState(KatranMonitorState state);
+  
+  /*
+   * setupGueEnvironment prepare katran to run w/ GUE encap (e.g. setting up
+   * src addresses for outer packets)
+   */
+  void setupGueEnvironment();
 
   /**
    * main configurations of katran

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -40,6 +40,7 @@ constexpr unsigned int kDefaultLruSize = 8000000;
 constexpr uint32_t kNoFlags = 0;
 std::string kNoExternalMap = "";
 std::string kDefaultHcInterface = "";
+std::string kAddressNotSpecified = "";
 } // namespace
 
 /**
@@ -143,6 +144,8 @@ struct KatranMonitorConfig {
  * @param std::string hcInterface interface where we want to attach hc bpf prog
  * @param KatranMonitorConfig monitorConfig for katran introspection
  * @param memlockUnlimited should katran set memlock to unlimited by default
+ * @param katranSrcV4 string ipv4 source address for GUE packets
+ * @param katranSrcV6 string ipv6 source address for GUE packets
  *
  * note about rootMapPath and rootMapPos:
  * katran has two modes of operation.
@@ -186,6 +189,8 @@ struct KatranConfig {
   uint32_t xdpAttachFlags = kNoFlags;
   struct KatranMonitorConfig monitorConfig;
   bool memlockUnlimited = true;
+  std::string katranSrcV4 = kAddressNotSpecified;
+  std::string katranSrcV6 = kAddressNotSpecified;
 };
 
 /**
@@ -244,6 +249,7 @@ struct KatranFeatures {
   bool srcRouting{false};
   bool inlineDecap{false};
   bool introspection{false};
+  bool gueEncap{false};
 };
 
 /**

--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -206,6 +206,13 @@
 #define COPY_INNER_PACKET_TOS 1
 #endif
 
+// defaut GUE dst port
+#ifndef GUE_DPORT
+#define GUE_DPORT 6080
+#endif
+
+#define GUE_CSUM 0
+
 // initial value for jhash hashing function, used to pick up a real server
 #ifndef INIT_JHASH_SEED
 #define INIT_JHASH_SEED CH_RINGS_SIZE
@@ -231,12 +238,29 @@
  *
  * INLINE_DECAP - allow do to inline ipip decapsulation in XDP context
  *
+ * GUE_ENCAP - use GUE (draft-ietf-intarea-gue) as encapsulation method
+ *
  * KATRAN_INTROSPECTION - katran will start to perfpipe packet's header which
  * have triggered specific events
  */
 #ifdef LPM_SRC_LOOKUP
 #define INLINE_DECAP
 #endif
+
+#ifdef GUE_ENCAP
+#define PCKT_ENCAP_V4 gue_encap_v4
+#define PCKT_ENCAP_V6 gue_encap_v6
+#else
+#define PCKT_ENCAP_V4 encap_v4
+#define PCKT_ENCAP_V6 encap_v6
+#endif
+
+
+/**
+ * positions in pckts_srcs table
+ */
+#define V4_SRC_INDEX 0
+#define V6_SRC_INDEX 1
 
 // maximum size of packets header which we would write to event pipe
 // if KATRAN_INTROSPECTION is enabled

--- a/katran/lib/bpf/balancer_kern.c
+++ b/katran/lib/bpf/balancer_kern.c
@@ -510,11 +510,11 @@ static inline int process_packet(void *data, __u64 off, void *data_end,
   }
 
   if (dst->flags & F_IPV6) {
-    if(!encap_v6(xdp, cval, is_ipv6, &pckt, dst, pkt_bytes)) {
+    if(!PCKT_ENCAP_V6(xdp, cval, is_ipv6, &pckt, dst, pkt_bytes)) {
       return XDP_DROP;
     }
   } else {
-    if(!encap_v4(xdp, cval, &pckt, dst, pkt_bytes)) {
+    if(!PCKT_ENCAP_V4(xdp, cval, &pckt, dst, pkt_bytes)) {
       return XDP_DROP;
     }
   }

--- a/katran/lib/bpf/balancer_maps.h
+++ b/katran/lib/bpf/balancer_maps.h
@@ -165,4 +165,18 @@ struct bpf_map_def SEC("maps") event_pipe = {
 BPF_ANNOTATE_KV_PAIR(event_pipe, int, __u32);
 
 #endif
+
+#ifdef GUE_ENCAP
+// map which src ip address for outer ip packet while using GUE encap
+// NOTE: This is not a stable API. This is to be reworked when static
+// variables will be available in mainline kernels
+struct bpf_map_def SEC("maps") pckt_srcs = {
+  .type = BPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(__u32),
+  .value_size = sizeof(struct real_definition),
+  .max_entries = 2,
+  .map_flags = NO_FLAGS,
+};
+BPF_ANNOTATE_KV_PAIR(pckt_srcs, __u32, struct real_definition);
+#endif
 #endif // of _BALANCER_MAPS

--- a/katran/lib/testing/CMakeLists.txt
+++ b/katran/lib/testing/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(xdptester STATIC
     XdpTester.h
     XdpTester.cpp
     KatranTestFixtures.h
+    KatranGueTestFixtures.h
     KatranOptionalTestFixtures.h
 )
 

--- a/katran/lib/testing/KatranGueTestFixtures.h
+++ b/katran/lib/testing/KatranGueTestFixtures.h
@@ -1,0 +1,402 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace katran {
+namespace testing {
+/**
+ * input packets has been generated with scapy. above each of em you can find
+ * a command which has been used to do so.
+ *
+ * format of the input data: <string, string>; 1st string is a base64 encoded
+ * packet. 2nd string is test's description
+ *
+ * format of the output data: <string, string>; 1st string is a base64 encoded
+ * packet which we are expecting to see after bpf program's run.
+ * 2nd string = bpf's program return code.
+ *
+ * to create pcap w/ scapy:
+ * 1) create packets
+ * 2) pckts = [ <created packets from above> ]
+ * 3) wrpcap(<path_to_file>, pckts)
+ */
+const std::vector<std::pair<std::string, std::string>> inputGueTestFixtures = {
+  //1
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
+    "packet to UDP based v4 VIP (and v4 real)"
+  },
+  //2
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "packet to TCP based v4 VIP (and v4 real)"
+  },
+  //3
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.2")/TCP(sport=31337, dport=42, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU3AqAEBCsgBAnppACoAAAAAAAAAAFAQIAAoCQAAa2F0cmFuIHRlc3QgcGt0",
+    "packet to TCP based v4 VIP (and v4 real; any dst ports)."
+  },
+  //4
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.3")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrUzAqAEBCsgBA3ppAFAAAAAAAAAAAFAQIAAn4gAAa2F0cmFuIHRlc3QgcGt0",
+    "packet to TCP based v4 VIP (and v6 real)"
+  },
+  //5
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "packet to TCP based v6 VIP (and v6 real)"
+  },
+  //6
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.3")/ICMP(type="echo-request")
+    "AgAAAAAAAQAAAAAACABFAAAcAAEAAEABrWzAqAEBCsgBAwgA9/8AAAAA",
+    "v4 ICMP echo-request"
+  },
+  //7
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/ICMPv6EchoRequest()
+    "AgAAAAAAAQAAAAAAht1gAAAAAAg6QPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABgACHtgAAAAA=",
+    "v6 ICMP echo-request"
+  },
+  //8
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.100.1", dst="10.200.1.1")/ICMP(type="dest-unreach", code="fragmentation-needed")/IP(src="10.200.1.1", dst="192.168.1.1")/TCP(sport=80, dport=31337)/"test katran pkt"
+    "AgAAAAAAAQAAAAAACABFAABTAAEAAEABSjfAqGQBCsgBAQMEypcAAAAARQAANwABAABABq1OCsgBAcCoAQEAUHppAAAAAAAAAABQAiAAGQEAAHRlc3Qga2F0cmFuIHBrdA==",
+    "v4 ICMP dest-unreachabe fragmentation-needed"
+  },
+  //9
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:200::1", dst="fc00:1::1")/ICMPv6PacketTooBig()/IPv6(src="fc00:1::1", dst="fc00:2::1")/TCP(sport=80,dport=31337)/"katran test packet"
+    "AgAAAAAAAQAAAAAAht1gAAAAAFY6QPwAAgAAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABAgCYMAAABQBgAAAAACYGQPwAAAEAAAAAAAAAAAAAAAH8AAACAAAAAAAAAAAAAAABAFB6aQAAAAAAAAAAUAIgAKiFAABrYXRyYW4gdGVzdCBwYWNrZXQ=",
+    "v6 ICMP packet-too-big"
+  },
+  //10
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1",ihl=6)/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABGAAA3AAEAAEAGrE7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "drop of IPv4 packet w/ options"
+  },
+  //11
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1",ihl=5,flags="MF")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEgAEAGjU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "drop of IPv4 fragmented packet"
+  },
+  //12
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1",nh=44)/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMsQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "drop of IPv6 fragmented packet"
+  },
+  //13
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1",ihl=5)/TCP(sport=31337, dport=82,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFIAAAAAAAAAAFAQIAAn4gAAa2F0cmFuIHRlc3QgcGt0",
+    "pass of v4 packet with dst not equal to any configured VIP"
+  },
+  //14
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=82,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUgAAAAAAAAAAUBAgAP1NAABrYXRyYW4gdGVzdCBwa3Q=",
+    "pass of v6 packet with dst not equal to any configured VIP"
+  },
+  //15
+  {
+    //Ether(src="0x1", dst="0x2")/ARP()
+    "AgAAAAAAAQAAAAAACAYAAQgABgQAAQAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "pass of arp packet"
+  },
+  //16
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "LRU hit"
+  },
+  //17
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.4")/TCP(sport=31337, dport=42, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrUvAqAEBCsgBBHppACoAAAAAAAAAAFAQIAAoBwAAa2F0cmFuIHRlc3QgcGt0",
+    "packet #1 dst port hashing only"
+  },
+  //18
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.100", dst="10.200.1.4")/TCP(sport=1337, dport=42, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrOjAqAFkCsgBBAU5ACoAAAAAAAAAAFAQIACc1AAAa2F0cmFuIHRlc3QgcGt0",
+    "packet #2 dst port hashing only"
+  },
+  //19
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.4")/TCP(sport=31337, dport=42, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA/AAEAAEAEvZesEAEBrBBkAUUAACsAAQAAQBGtT8CoAQEKyAEBemkAUAAXl95rYXRyYW4gdGVzdCBwa3Q=",
+    "ipinip packet"
+
+  },
+  //20
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAAEspQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACYAAAAAAjBkD8AAACAAAAAAAAAAAAAAAB/AAAAQAAAAAAAAAAAAAAAXppAFAAAAAAAAAAAFAQIAD9TwAAa2F0cmFuIHRlc3QgcGt0",
+    "ipv6inipv6 packet"
+  },
+  //21
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACsEQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "ipv4inipv6 packet"
+  },
+  //22
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\xcf\xfa\xce\xb0\x01\x08\x41\x02\x03\x04\x05\x06\x07\x00\x00\x01\x11\x01quic data\x00@'
+    "AgAAAAAAAQAAAAAACABFAAA5AAEAAEARrRTAqAEqCsgBBXppAbsAJbdsz/rOsAEIQQIDBAUGBwAAAREBcXVpYyBkYXRhAEA=",
+    "QUIC: long header. Client Initial type. LRU miss"
+  },
+  //23
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\xdf\xfa\xce\xb0\x01\x08\x43\xFF\x33\x44\x55\x66\x77\x88\x00\x01\x11\x01quic data\x00@'
+    "AgAAAAAAAQAAAAAACABFAAA5AAEAAEARrRTAqAEqCsgBBXppAbsAJbNG3/rOsAEIQ/8zRFVmd4gAAREBcXVpYyBkYXRhAEA=",
+    "QUIC: long header. 0-RTT Protected. CH. LRU hit."
+  },
+  //24
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\xef\xfa\xce\xb0\x01\x08\x44\x01\x03\x04\x05\x06\x07\x00\x00\x01\x11\x01quic data\x00@'
+    "AgAAAAAAAQAAAAAACABFAAA5AAEAAEARrRTAqAEqCsgBBXppAbsAJZRt7/rOsAEIRAEDBAUGBwAAAREBcXVpYyBkYXRhAEA=",
+    "QUIC: long header. Handshake. v4 vip v6 real. Conn Id based."
+  },
+  //25
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\xff\xfa\xce\xb0\x01\x08\x44\x01\x03\x04\x05\x06\x07\x00\x00\x01\x11\x01quic data\x00@'
+    "AgAAAAAAAQAAAAAACABFAAA5AAEAAEARrRTAqAEqCsgBBXppAbsAJYRt//rOsAEIRAEDBAUGBwAAAREBcXVpYyBkYXRhAEA=",
+    "QUIC: long header. Retry. v4 vip v6 real. Conn Id based."
+  },
+  //26
+  {
+    // Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::42", dst="fc00:1::2")/UDP(sport=31337, dport=443)/'\xcf\xfa\xce\xb0\x01\x08\x44\x01\x03\x04\x05\x06\x07\x00\x00\x01\x11\x01quic data\x00@'
+    "AgAAAAAAAQAAAAAAht1gAAAAACURQPwAAAIAAAAAAAAAAAAAAEL8AAABAAAAAAAAAAAAAAACemkBuwAlicTP+s6wAQhEAQMEBQYHAAABEQFxdWljIGRhdGEAQA==",
+    "QUIC: long header. client initial. v6 vip v6 real. LRU miss"
+  },
+  //27
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\x00'
+    "AgAAAAAAAQAAAAAACABFAAAdAAEAAEARrTDAqAEqCsgBBXppAbsACbYYAA==",
+    "QUIC: short header. No connection id. CH. LRU hit"
+  },
+  //28
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\x00\x41\x00\x83\x04\x05\x06\x07\x00@'
+    "AgAAAAAAAQAAAAAACABFAAAmAAEAAEARrSfAqAEqCsgBBXppAbsAEqr2AEEAgwQFBgcAQA==",
+    "QUIC: short header w/ connection id"
+  },
+  //29
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\x00\x41\x11\x00\x00\x00\x00\x00\x00@'
+    "AgAAAAAAAQAAAAAACABFAAAmAAEAAEARrSfAqAEqCsgBBXppAbsAEqSFAEERAAAAAAAAQA==",
+    "QUIC: short header w/ connection id but non-existing mapping"
+  },
+  //30
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.42", dst="10.200.1.5")/UDP(sport=31337, dport=443)/'\x00\x40\x00\x03\x04\x05\x06\x07\x00@'
+    "AgAAAAAAAQAAAAAACABFAAAmAAEAAEARrSfAqAEqCsgBBXppAbsAEqt3AEAAAwQFBgcAQA==",
+    "QUIC: short header w/ conn id. host id = 0. CH. LRU hit"
+  },
+  //31
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1", tos=0x8c)/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFjAA3AAEAAEAGrMLAqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "packet to TCP based v4 VIP (and v4 real) + ToS in IPV4"
+  },
+  //32
+  {
+    // Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1", tc=0x8c)/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1owAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "packet to TCP based v6 VIP (and v6 real) with ToS / tc set"
+  },
+
+};
+
+const std::vector<std::pair<std::string, std::string>> outputGueTestFixtures = {
+  //1
+  {
+    "AADerb6vAgAAAAAACABFAABHAAAAAEARWX8KAA0lCgAAA2h7F8AAMwAARQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //2
+  {
+    "AADerb6vAgAAAAAACABFAABTAAAAAEARWXMKAA0lCgAAA2h7F8AAPwAARQAANwABAABABq1OwKgBAQrIAQF6aQBQAAAAAAAAAABQECAAJ+QAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //3
+  {
+    "AADerb6vAgAAAAAACABFAABTAAAAAEARWXQKAA0lCgAAAmh7F8AAPwAARQAANwABAABABq1NwKgBAQrIAQJ6aQAqAAAAAAAAAABQECAAKAkAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //4
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAD8RQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAABe2gXwAA/AABFAAA3AAEAAEAGrUzAqAEBCsgBA3ppAFAAAAAAAAAAAFAQIAAn4gAAa2F0cmFuIHRlc3QgcGt0",
+    "XDP_TX"
+  },
+  //5
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAADemkXwABTAABgAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //6
+  {
+    "AQAAAAAAAgAAAAAACABFAAAcAAEAAEABrWwKyAEDwKgBAQAA//8AAAAA",
+    "XDP_TX",
+  },
+  //7
+  {
+    "AQAAAAAAAgAAAAAAht1gAAAAAAg6QPwAAAEAAAAAAAAAAAAAAAH8AAACAAAAAAAAAAAAAAABgQCGtgAAAAA=",
+    "XDP_TX"
+  },
+  //8
+  {
+    "AADerb6vAgAAAAAACABFAABvAAAAAEARWVcKAA0lCgAAA2h7F8AAWwAARQAAUwABAABAAUo3wKhkAQrIAQEDBMqXAAAAAEUAADcAAQAAQAatTgrIAQHAqAEBAFB6aQAAAAAAAAAAUAIgABkBAAB0ZXN0IGthdHJhbiBwa3Q=",
+    "XDP_TX"
+  },
+  //9
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAIYRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAADemkXwACGAABgAAAAAFY6QPwAAgAAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABAgCYMAAABQBgAAAAACYGQPwAAAEAAAAAAAAAAAAAAAH8AAACAAAAAAAAAAAAAAABAFB6aQAAAAAAAAAAUAIgAKiFAABrYXRyYW4gdGVzdCBwYWNrZXQ=",
+    "XDP_TX"
+  },
+  //10
+  {
+    "AgAAAAAAAQAAAAAACABGAAA3AAEAAEAGrE7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "XDP_DROP"
+  },
+  //11
+  {
+    "AgAAAAAAAQAAAAAACABFAAA3AAEgAEAGjU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "XDP_DROP"
+  },
+  //12
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAACMsQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_DROP"
+  },
+  //13
+  {
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFIAAAAAAAAAAFAQIAAn4gAAa2F0cmFuIHRlc3QgcGt0",
+    "XDP_PASS"
+  },
+  //14
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUgAAAAAAAAAAUBAgAP1NAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_PASS"
+  },
+  //15
+  {
+    "AgAAAAAAAQAAAAAACAYAAQgABgQAAQAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "XDP_PASS"
+  },
+  //16
+  {
+    "AADerb6vAgAAAAAACABFAABTAAAAAEARWXMKAA0lCgAAA2h7F8AAPwAARQAANwABAABABq1OwKgBAQrIAQF6aQBQAAAAAAAAAABQECAAJ+QAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //17
+  {
+    "AADerb6vAgAAAAAACABFAABTAAAAAEARWXQKAA0lCgAAAioAF8AAPwAARQAANwABAABABq1LwKgBAQrIAQR6aQAqAAAAAAAAAABQECAAKAcAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //18
+  {
+    "AADerb6vAgAAAAAACABFAABTAAAAAEARWXQKAA0lCgAAAioAF8AAPwAARQAANwABAABABqzowKgBZArIAQQFOQAqAAAAAAAAAABQECAAnNQAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //19
+  {
+    "AgAAAAAAAQAAAAAACABFAAA/AAEAAEAEvZesEAEBrBBkAUUAACsAAQAAQBGtT8CoAQEKyAEBemkAUAAXl95rYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_PASS"
+
+  },
+  //20
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAAEspQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACYAAAAAAjBkD8AAACAAAAAAAAAAAAAAAB/AAAAQAAAAAAAAAAAAAAAXppAFAAAAAAAAAAAFAQIAD9TwAAa2F0cmFuIHRlc3QgcGt0",
+    "XDP_PASS"
+  },
+  //21
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAACsEQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_PASS"
+  },
+  //22
+  {
+    "AADerb6vAgAAAAAACABFAABVAAAAAEARWXIKAA0lCgAAAmhQF8AAQQAARQAAOQABAABAEa0UwKgBKgrIAQV6aQG7ACW3bM/6zrABCEECAwQFBgcAAAERAXF1aWMgZGF0YQBA",
+    "XDP_TX"
+  },
+  //23
+  {
+    "AADerb6vAgAAAAAACABFAABVAAAAAEARWXIKAA0lCgAAAmhQF8AAQQAARQAAOQABAABAEa0UwKgBKgrIAQV6aQG7ACWzRt/6zrABCEP/M0RVZneIAAERAXF1aWMgZGF0YQBA",
+    "XDP_TX"
+  },
+  //24
+  {
+    "AADerb6vAgAAAAAACABFAABVAAAAAEARWXMKAA0lCgAAAWhQF8AAQQAARQAAOQABAABAEa0UwKgBKgrIAQV6aQG7ACWUbe/6zrABCEQBAwQFBgcAAAERAXF1aWMgZGF0YQBA",
+    "XDP_TX"
+  },
+  //25
+  {
+    "AADerb6vAgAAAAAACABFAABVAAAAAEARWXMKAA0lCgAAAWhQF8AAQQAARQAAOQABAABAEa0UwKgBKgrIAQV6aQG7ACWEbf/6zrABCEQBAwQFBgcAAAERAXF1aWMgZGF0YQBA",
+    "XDP_TX"
+  },
+  //26
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFURQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAABemkXwABVAABgAAAAACURQPwAAAIAAAAAAAAAAAAAAEL8AAABAAAAAAAAAAAAAAACemkBuwAlicTP+s6wAQhEAQMEBQYHAAABEQFxdWljIGRhdGEAQA==",
+    "XDP_TX"
+  },
+  //27
+  {
+    "AADerb6vAgAAAAAACABFAAA5AAAAAEARWY4KAA0lCgAAAmhQF8AAJQAARQAAHQABAABAEa0wwKgBKgrIAQV6aQG7AAm2GAA=",
+    "XDP_TX"
+  },
+  //28
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAC4RQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAACe0MXwAAuAABFAAAmAAEAAEARrSfAqAEqCsgBBXppAbsAEqr2AEEAgwQFBgcAQA==",
+    "XDP_TX"
+  },
+  //29
+  {
+    "AADerb6vAgAAAAAACABFAABCAAAAAEARWYYKAA0lCgAAAWhQF8AALgAARQAAJgABAABAEa0nwKgBKgrIAQV6aQG7ABKkhQBBEQAAAAAAAEA=",
+    "XDP_TX"
+  },
+  //30
+  {
+    "AADerb6vAgAAAAAACABFAABCAAAAAEARWYUKAA0lCgAAAmhQF8AALgAARQAAJgABAABAEa0nwKgBKgrIAQV6aQG7ABKrdwBAAAMEBQYHAEA=",
+    "XDP_TX"
+  },
+  //31
+  {
+    "AADerb6vAgAAAAAACABFjABTAAAAAEARWOcKAA0lCgAAA2h7F8AAPwAARYwANwABAABABqzCwKgBAQrIAQF6aQBQAAAAAAAAAABQECAAJ+QAAGthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //32
+  {
+    "AADerb6vAgAAAAAAht1owAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAADemkXwABTAABowAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+
+};
+
+} // namespace testing
+} // namespace katran

--- a/katran/lib/testing/katran_tester.cpp
+++ b/katran/lib/testing/katran_tester.cpp
@@ -27,6 +27,7 @@
 
 #include "KatranOptionalTestFixtures.h"
 #include "KatranTestFixtures.h"
+#include "KatranGueTestFixtures.h"
 #include "XdpTester.h"
 #include "katran/lib/KatranLb.h"
 #include "katran/lib/KatranLbStructs.h"
@@ -41,6 +42,7 @@ DEFINE_bool(print_base64, false, "print packets in base64 from pcap file");
 DEFINE_bool(test_from_fixtures, false, "run tests on predefined dataset");
 DEFINE_bool(perf_testing, false, "run perf tests on predefined dataset");
 DEFINE_bool(optional_tests, false, "run optional (kernel specific) tests");
+DEFINE_bool(gue, false, "run GUE tests instead of IPIP ones");
 DEFINE_int32(repeat, 1000000, "perf test runs for single packet");
 DEFINE_int32(position, -1, "perf test runs for single packet");
 DEFINE_bool(iobuf_storage, false, "test iobuf storage for katran monitor");
@@ -383,8 +385,13 @@ int main(int argc, char** argv) {
   katran::TesterConfig config;
   config.inputFileName = FLAGS_pcap_input;
   config.outputFileName = FLAGS_pcap_output;
-  config.inputData = katran::testing::inputTestFixtures;
-  config.outputData = katran::testing::outputTestFixtures;
+  if (FLAGS_gue) {
+    config.inputData = katran::testing::inputGueTestFixtures;
+    config.outputData = katran::testing::outputGueTestFixtures;
+  } else {
+    config.inputData = katran::testing::inputTestFixtures;
+    config.outputData = katran::testing::outputTestFixtures;
+  }
   katran::XdpTester tester(config);
   if (FLAGS_print_base64) {
     if (FLAGS_pcap_input.empty()) {
@@ -410,7 +417,11 @@ int main(int argc, char** argv) {
                                kNoExternalMap,
                                kDefaultKatranPos,
                                kNoHc};
+
   kconfig.monitorConfig = kmconfig;
+  kconfig.katranSrcV4 = "10.0.13.37";
+  kconfig.katranSrcV6 = "fc00:2307::1337";
+
   katran::KatranLb lb(kconfig);
   lb.loadBpfProgs();
   auto balancer_prog_fd = lb.getKatranProgFd();

--- a/tools/wireshark/README.md
+++ b/tools/wireshark/README.md
@@ -1,0 +1,9 @@
+# wireshark plugin to parse GUE variant 1 encapsulation
+
+## instalation:
+in your home dir create this directory:
+```
+mkdir -p ~/.config/wireshark/plugins/guev1
+```
+
+then copy guev1.lua into it. wireshark on startup automatically enables this plugin and would try to parse everything w/ UDP destination port 6080 as GUEv1 encapsulated

--- a/tools/wireshark/guev1.lua
+++ b/tools/wireshark/guev1.lua
@@ -1,0 +1,28 @@
+-- wireshark dissector for GUE variant 1
+
+do
+  local ip = Dissector.get("ip")
+  local ipv6 = Dissector.get("ipv6")
+
+  local guev1 = Proto("guev1", "GUE variant 1")
+  local proto = ProtoField.new("Protocol", "guev1.proto", ftypes.UINT8, nil, base.DEC, 0xF0)
+  guev1.fields = {proto}
+
+  local proto_field = Field.new("guev1.proto")
+
+  function guev1.dissector(tvb, pinfo, tree)
+    pinfo.cols.protocol:set("GUEv1")
+    
+    local subtree = tree:add(guev1, tvb(0,1))
+    subtree:add(proto, tvb(0,1))
+    
+    if proto_field()() == 6 then
+      ipv6:call(tvb, pinfo, tree)
+    else
+      ip:call(tvb, pinfo, tree)
+    end
+  end
+
+  local udp_table = DissectorTable.get("udp.port")
+  udp_table:add(6080, guev1)
+end


### PR DESCRIPTION
this is initial work to add GUE encapsulation option for katran.
Reason behind this is that currently we are using IPIP. but for IPIP to
play nice w/ ECMP and RSS we are "faking" src ip of outer IP header.
that makes debuging anything related to "from which load balancer i have
recved this flow" hard. GUE would allow us to have benefit of preserving
(or setting to whatever we want) source IP and at the same time allow
for ECMP/RSS to works (as network or NICs are going to use src port
for hashing. which is going to be unique per flow). the price for this
is 8 bytes of UDP header.

This diff adds gue encapsulation in forwarding plane. we are adding
variant 1 from https://tools.ietf.org/html/draft-ietf-intarea-gue-07
(aka no additional headers w/ metadata)
what is missing for now is:
- gue based encap for healthchecks
- gue decapsulation.

to build katran w/ GUE encapsulation it must be compile w/
-DGUE_ENCAP option.

Also as a part of this diff dissector for wireshark was added
(so encapsulated packets would be visible in wireshark).

Tests:
katran_tester:
added new test fixtures for GUE encap + "-gue" option to use em.
to see the output of the test (and to make sure that everything looks
sane) you can run em with -gue and -pcap_output=/tmp/test.pcap
in that case test.pcap would contain all the input and output packets
of the test. for GUE we are forcing udp checksum to be 0 for outer
packet so some "csum failed" output in wireshark is expected.
example of pcap output: https://gist.github.com/tehnerd/50a8ee7c47000941c3e41872d2fa6136

actual tests w/ katran + test host:
(w/ modifications in example grpc server (which are not in this diff):
```
diff --git a/example_grpc/katran_server.cpp b/example_grpc/katran_server.cpp
index b3c17ad..8b17118 100644
--- a/example_grpc/katran_server.cpp
+++ b/example_grpc/katran_server.cpp
@@ -129,6 +129,8 @@ int main(int argc, char** argv) {
   config.forwardingCores = forwardingCores;
   config.numaNodes = numaNodes;
   config.hcInterface = FLAGS_hc_intf;
+  config.katranSrcV4 = "10.0.13.37";
+  config.katranSrcV6 = "fc00:2307::1337";
```

katran's config:
```
2019/10/03 17:06:23 vips len 2
VIP:            fc00:1::1 Port:     22 Protocol: tcp
Vip's flags:
 ->fc00::1           weight: 1
VIP:             10.0.0.1 Port:     22 Protocol: tcp
Vip's flags:
 ->fc00::1           weight: 1
 ->192.168.102.129   weight: 1
exiting
```

reals configuration (to support gue):
```
modprobe fou
ip fou add port 6080 gue
ip link add name gue_v4 type ipip external encap gue encap-sport auto encap dport 6080
ip link set gue_v4 up
sudo net.ipv4.conf.gue_v4.rp_filter=0
net.ipv4.conf.default.rp_filter=0
ip fou add porto 6080 gue -6
ip link add name gue_v6 type ip6tnl external encap gue encap-sport auto encap-dport 6080
ip link set up dev gue_v6

some outputs:

tehnerd@tbox1:~$ ip fou show
port 6080 gue -6
port 6080 gue

tehnerd@tbox1:~$ ip -json link show dev gue_v4
[{
        "ifindex": 7,
        "ifname": "gue_v4",
        "link": null,
        "flags": ["NOARP","UP","LOWER_UP"],
        "mtu": 1480,
        "qdisc": "noqueue",
        "operstate": "UNKNOWN",
        "linkmode": "DEFAULT",
        "group": "default",
        "txqlen": 1000,
        "link_type": "ipip",
        "address": "0.0.0.0",
        "broadcast": "0.0.0.0"
    }
]

tehnerd@tbox1:~$ ip -json link show dev gue_v6
[{
        "ifindex": 9,
        "ifname": "gue_v6",
        "link": null,
        "flags": ["NOARP","UP","LOWER_UP"],
        "mtu": 1452,
        "qdisc": "noqueue",
        "operstate": "UNKNOWN",
        "linkmode": "DEFAULT",
        "group": "default",
        "txqlen": 1000,
        "link_type": "tunnel6",
        "address": "::",
        "broadcast": "::"
    }
]

```

v4 in v4:
vip is 10.0.0.1 in dump we are see packets which goes to load balancer
(first one) then gue from load balancer to local server and then reply
from local server to the client. this convo basically means that local
server was able to decap v4inv4 gue (it passed all the checks,
encapsulated packet was delivered to application and application
replied).

```
16:58:51.008903 IP 192.168.102.140.60000 > 10.0.0.1.22: Flags [S], seq 1298498081, win 32768, length 0
16:58:51.010958 IP 10.0.13.37.1638 > 192.168.102.129.6080: UDP, length 40
16:58:51.010995 IP 10.0.0.1.22 > 192.168.102.140.60000: Flags [S.], seq 122077391, ack 1298498082, win 29200, options [mss 1460], length 0
```

v6inv6:
same as above.

```
17:02:55.576750 IP6 fc00::10.60000 > fc00:1::1.22: Flags [S], seq 1298498081, win 32768, length 0
17:02:55.578319 IP6 fc00:2307::1337.60000 > fc00::1.6080: UDP, length 60
17:02:55.578498 IP6 fc00:1::1.22 > fc00::10.60000: Flags [S.], seq 3064362547, ack 1298498082, win 28800, options [mss 1440], length 0
```

v4inv6:
17:05:15.541911 IP 192.168.102.140.60004 > 10.0.0.1.22: Flags [S], seq 1298498081, win 32768, length 0
17:05:15.543775 IP6 fc00:2307::1337.36072 > fc00::1.6080: UDP, length 40
17:05:15.543812 IP 10.0.0.1.22 > 192.168.102.140.60004: Flags [S.], seq 173938774, ack 1298498082, win 29200, options [mss 1460], length 0