### PR TITLE
[build]: fixing travis build

### DIFF
--- a/build_katran.sh
+++ b/build_katran.sh
@@ -397,6 +397,7 @@ get_grpc() {
     mkdir -p "$GRPC_BUILD_DIR"
     cd "$GRPC_BUILD_DIR" || exit
     cmake -DCXX_STD=gnu++14                         \
+      -DCMAKE_CXX_FLAGS=-Wno-unused-result          \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
       -DCMAKE_PREFIX_PATH="$INSTALL_DIR"            \
       -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"         \

--- a/example_grpc/CMakeLists.txt
+++ b/example_grpc/CMakeLists.txt
@@ -12,6 +12,7 @@ find_library(GRPC libgrpc.a grpc PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
 find_library(GRPC++ libgrpc++.a grpc++ PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
 find_library(CARES libcares.a cares PATHS ${CARES_LIBRARIES_PATH} NO_DEFAULT_PATH)
 find_library(GRPC_UNSECURE libgrpc_unsecure.a grpc_unsecure PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
+find_library(UPB libupb.a grpc PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
 find_library(LIBIBERTY libiberty.a iberty)
 find_library(DL dl)
 find_library(EVENT libevent.a event)
@@ -93,6 +94,7 @@ target_link_libraries(katran_server_grpc
   "${LIBIBERTY}"
   "${GRPC_UNSECURE}"
   "${LIBZ}"
+  "${UPB}"
   katran_service_handler
   grpc_signal_handler
   "-Wl,--end-group"


### PR DESCRIPTION
currently, after grpc updated deps on boringssl, travis build is broken.
(and it was broken for 20+ days). fixing it (by starting to ignore
unused variables in boring ssl; this was the easiest/fastest way to fix
it)