### PR TITLE
[gue]: adding gue decapsulation feature

### DIFF
--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -25,6 +25,11 @@
 #define BE_ETH_P_IP 8
 #define BE_ETH_P_IPV6 56710
 
+
+// GUE variant 1 using first four bits of inner packet as a pseudo header
+// we are using last two of this four bits to distinct v4 vs v6. see RFC for more details
+#define GUEV1_IPV6MASK 0x30
+
 // functions could return ether drop, pass, tx or we need to further
 // process a packet to figure out what to do with it
 #define FURTHER_PROCESSING -1
@@ -113,8 +118,6 @@
 #define F_ICMP (1 << 0)
 // tcp packet had syn flag set
 #define F_SYN_SET (1 << 1)
-// packet was decapsulated inline
-#define F_INLINE_DECAP (1 << 2)
 
 // ttl for outer ipip packet
 #ifndef DEFAULT_TTL
@@ -243,7 +246,14 @@
  *
  * LPM_SRC_LOOKUP - allow to do src based routing/dst decision override
  *
- * INLINE_DECAP - allow do to inline ipip decapsulation in XDP context
+ * INLINE_DECAP_GENERIC - enables features to allow pckt specific inline decapsulation
+ * 
+ * INLINE_DECAP - allow to do inline decapsulation for ipip and enables additional features
+ * to do so
+ * 
+ * INLINE_DECAP_IPIP - allow do to inline ipip decapsulation in XDP context
+ * 
+ * INLINE_DECAP_GUE - allow to do inline gue decapsulation in XDP context
  *
  * GUE_ENCAP - use GUE (draft-ietf-intarea-gue) as encapsulation method
  *
@@ -251,8 +261,28 @@
  * have triggered specific events
  */
 #ifdef LPM_SRC_LOOKUP
+#ifndef INLINE_DECAP
+#ifndef INLINE_DECAP_GUE
 #define INLINE_DECAP
+#endif // of INLINE_DECAP_GUE
+#endif // of INLINE_DECAP
+#endif // of LPM_SRC_LOOKUP
+
+#ifdef INLINE_DECAP
+#define INLINE_DECAP_IPIP
 #endif
+
+#ifdef INLINE_DECAP_IPIP
+#ifndef INLINE_DECAP_GENERIC
+#define INLINE_DECAP_GENERIC
+#endif // of INLINE_DECAP_GENERIC
+#endif // of INLINE_DECAP_IPIP
+
+#ifdef INLINE_DECAP_GUE
+#ifndef INLINE_DECAP_GENERIC
+#define INLINE_DECAP_GENERIC
+#endif // of INLINE_DECAP_GENERIC
+#endif // of INLINE_DECAP_GUE
 
 #ifdef GUE_ENCAP
 #define PCKT_ENCAP_V4 gue_encap_v4

--- a/katran/lib/bpf/balancer_helpers.h
+++ b/katran/lib/bpf/balancer_helpers.h
@@ -121,7 +121,7 @@ static inline void submit_event(struct xdp_md *ctx, void *map,
   bpf_perf_event_output(ctx, map, flags, &md, sizeof(struct event_metadata));
 }
 
-#ifdef INLINE_DECAP
+#ifdef INLINE_DECAP_GENERIC
 __attribute__((__always_inline__))
 static inline int recirculate(struct xdp_md *ctx) {
   int i = RECIRCULATION_INDEX;
@@ -129,7 +129,7 @@ static inline int recirculate(struct xdp_md *ctx) {
   // we should never hit this
   return XDP_PASS;
 }
-#endif // INLINE_DECAP
+#endif // of INLINE_DECAP_GENERIC
 
 __attribute__((__always_inline__))
 static inline int decrement_ttl(void *data, void *data_end, int offset, bool is_ipv6) {

--- a/katran/lib/bpf/balancer_kern.c
+++ b/katran/lib/bpf/balancer_kern.c
@@ -236,11 +236,39 @@ static inline int process_l3_headers(struct packet_description *pckt,
   return FURTHER_PROCESSING;
 }
 
-#ifdef INLINE_DECAP
+#ifdef INLINE_DECAP_GENERIC
 __attribute__((__always_inline__))
-static inline int process_encaped_pckt(void **data, void **data_end,
-                                       struct xdp_md *xdp, bool *is_ipv6,
-                                       __u8 *protocol, bool pass) {
+static inline int check_decap_dst(struct packet_description *pckt,
+                                  bool is_ipv6, bool *pass) {
+    struct address dst_addr = {};
+    struct lb_stats *data_stats;
+
+    if (is_ipv6) {
+      memcpy(dst_addr.addrv6, pckt->flow.dstv6, 16);
+    } else {
+      dst_addr.addr = pckt->flow.dst;
+    }
+    __u32 *decap_dst_flags = bpf_map_lookup_elem(&decap_dst, &dst_addr);
+
+    if (decap_dst_flags) {
+      *pass = false;
+      __u32 stats_key = MAX_VIPS + REMOTE_ENCAP_CNTRS;
+      data_stats = bpf_map_lookup_elem(&stats, &stats_key);
+      if (!data_stats) {
+        return XDP_DROP;
+      }
+      data_stats->v1 += 1;
+    }
+    return FURTHER_PROCESSING;
+}
+
+#endif // of INLINE_DECAP_GENERIC
+
+#ifdef INLINE_DECAP_IPIP
+__attribute__((__always_inline__))
+static inline int process_encaped_ipip_pckt(void **data, void **data_end,
+                                            struct xdp_md *xdp, bool *is_ipv6,
+                                            __u8 *protocol, bool pass) {
   int action;
   if (*protocol == IPPROTO_IPIP) {
     if (*is_ipv6) {
@@ -282,7 +310,60 @@ static inline int process_encaped_pckt(void **data, void **data_end,
   }
   return recirculate(xdp);
 }
-#endif // INLINE_DECAP
+#endif // of INLINE_DECAP_IPIP
+
+#ifdef INLINE_DECAP_GUE
+__attribute__((__always_inline__))
+static inline int process_encaped_gue_pckt(void **data, void **data_end,
+                                           struct xdp_md *xdp, bool is_ipv6,
+                                           bool pass) {
+  int offset = 0;
+  int action;
+  if (is_ipv6) {
+    __u8 v6 = 0;
+    offset = sizeof(struct ipv6hdr) + sizeof(struct eth_hdr) +
+      sizeof(struct udphdr);
+    // 1 byte for gue v1 marker to figure out what is internal protocol
+    if ((*data + offset + 1) > *data_end) {
+      return XDP_DROP;
+    }
+    v6 = ((__u8*)(*data))[offset];
+    v6 &= GUEV1_IPV6MASK;
+    if (v6) {
+      // inner packet is ipv6 as well
+      action = decrement_ttl(*data, *data_end, offset, true);      
+      if (!gue_decap_v6(xdp, data, data_end, false)) {
+        return XDP_DROP;
+      }
+    } else {
+      // inner packet is ipv4
+      action = decrement_ttl(*data, *data_end, offset, false);      
+      if (!gue_decap_v6(xdp, data, data_end, true)) {
+        return XDP_DROP;
+      }
+    }
+  } else {
+    offset = sizeof(struct iphdr) + sizeof(struct eth_hdr) +
+      sizeof(struct udphdr);
+    if ((*data + offset) > *data_end) {
+      return XDP_DROP;
+    }
+    action = decrement_ttl(*data, *data_end, offset, false);
+    if (!gue_decap_v4(xdp, data, data_end)) {
+        return XDP_DROP;
+    }
+  }
+  if (action >= 0) {
+    return action;
+  }
+  if (pass) {
+    return XDP_PASS;
+  }
+  return recirculate(xdp);
+}
+#endif // of INLINE_DECAP_GUE
+
+
 
 __attribute__((__always_inline__))
 static inline int process_packet(void *data, __u64 off, void *data_end,
@@ -308,30 +389,16 @@ static inline int process_packet(void *data, __u64 off, void *data_end,
   }
   protocol = pckt.flow.proto;
 
-  #ifdef INLINE_DECAP
+  #ifdef INLINE_DECAP_IPIP
   if (protocol == IPPROTO_IPIP || protocol == IPPROTO_IPV6) {
     bool pass = true;
-    struct address dst_addr = {};
-    if (is_ipv6) {
-      memcpy(dst_addr.addrv6, pckt.flow.dstv6, 16);
-    } else {
-      dst_addr.addr = pckt.flow.dst;
+    action = check_decap_dst(&pckt, is_ipv6, &pass);
+    if (action >= 0) {
+      return action;
     }
-    __u32 *decap_dst_flags = bpf_map_lookup_elem(&decap_dst, &dst_addr);
-
-    if (decap_dst_flags) {
-      __u32 stats_key = MAX_VIPS + REMOTE_ENCAP_CNTRS;
-      data_stats = bpf_map_lookup_elem(&stats, &stats_key);
-      if (!data_stats) {
-        return XDP_DROP;
-      }
-      pass = false;
-      data_stats->v1 += 1;
-    }
-
-    return process_encaped_pckt(&data, &data_end, xdp, &is_ipv6, &protocol, pass);
+    return process_encaped_ipip_pckt(&data, &data_end, xdp, &is_ipv6, &protocol, pass);
   }
-  #endif // INLINE_DECAP
+  #endif // INLINE_DECAP_IPIP
 
   if (protocol == IPPROTO_TCP) {
     if (!parse_tcp(data, data_end, is_ipv6, &pckt)) {
@@ -341,6 +408,16 @@ static inline int process_packet(void *data, __u64 off, void *data_end,
     if (!parse_udp(data, data_end, is_ipv6, &pckt)) {
       return XDP_DROP;
     }
+  #ifdef INLINE_DECAP_GUE
+    if (pckt.flow.port16[1] == bpf_htons(GUE_DPORT)) {
+      bool pass = true;
+      action = check_decap_dst(&pckt, is_ipv6, &pass);
+      if (action >= 0) {
+        return action;
+      }
+      return process_encaped_gue_pckt(&data, &data_end, xdp, is_ipv6, pass);
+    }
+  #endif // of INLINE_DECAP_GUE
   } else {
     // send to tcp/ip stack
     return XDP_PASS;

--- a/katran/lib/bpf/balancer_maps.h
+++ b/katran/lib/bpf/balancer_maps.h
@@ -141,7 +141,7 @@ struct bpf_map_def SEC("maps") lpm_src_v6 = {
 BPF_ANNOTATE_KV_PAIR(lpm_src_v6, struct v6_lpm_key, __u32);
 
 #endif
-#ifdef INLINE_DECAP
+#ifdef INLINE_DECAP_GENERIC
 struct bpf_map_def SEC("maps") decap_dst = {
   .type = BPF_MAP_TYPE_HASH,
   .key_size = sizeof(struct address),

--- a/katran/lib/testing/CMakeLists.txt
+++ b/katran/lib/testing/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(xdptester STATIC
     KatranTestFixtures.h
     KatranGueTestFixtures.h
     KatranOptionalTestFixtures.h
+    KatranGueOptionalTestFixtures.h
 )
 
 target_link_libraries(xdptester

--- a/katran/lib/testing/KatranGueOptionalTestFixtures.h
+++ b/katran/lib/testing/KatranGueOptionalTestFixtures.h
@@ -1,0 +1,191 @@
+// @nolint
+
+/* 
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace katran {
+namespace testing {
+/**
+ * see KatranTestFixtures.h on how to generate input and output data
+ */
+using TestFixture = std::vector<std::pair<std::string, std::string>>;
+const TestFixture inputGueOptionalTestFixtures = {
+  //1
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/("katran test pkt"*100)
+    "AgAAAAAAAQAAAAAACABFAAX4AAEAAEARp4LAqAEBCsgBAXppAFAF5Og2a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0a2F0cmFuIHRlc3QgcGt0",
+    "ICMPv4 packet too big. ICMP_TOOBIG_GENERATION and 4.17+ kernel is required"
+  },
+  //2
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/("katran test pkt"*100)
+    "AgAAAAAAAQAAAAAAht1gAAAABfAGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAFN1AABrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3Q=",
+    "ICMPv6 packet too big. ICMP_TOOBIG_GENERATION and 4.17+ kernel is required"
+  },
+  //3
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
+    "ipv4: lpm cached flow. LPM_SRC_LOOKUP is required"
+  },
+  //4
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.2", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU7AqAECCsgBAXppAFAAF5fda2F0cmFuIHRlc3QgcGt0",
+    "ipv4: lpm src lookup /17. LPM_SRC_LOOKUP is required"
+  },
+  //5
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.100.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARSk/AqGQBCsgBAXppAFAAFzTea2F0cmFuIHRlc3QgcGt0",
+    "ipv4: lpm src lookup /24 . LPM_SRC_LOOKUP is required"
+  },
+  //6
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.200.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEAR5k7AqMgBCsgBAXppAFAAF9Dda2F0cmFuIHRlc3QgcGt0",
+    "ipv4: lpm miss. LPM_SRC_LOOKUP is required"
+  },
+  //7
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::2", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1OAABrYXRyYW4gdGVzdCBwa3Q=",
+    "ipv6: lpm src lookup /64. LPM_SRC_LOOKUP is required"
+  },
+  //8
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2307::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAIwcAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpKAABrYXRyYW4gdGVzdCBwa3Q=",
+    "ipv6: lpm src lookup /32. LPM_SRC_LOOKUP is required"
+  },
+  //9
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2308:1::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAIwgAAQAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "ipv6: lpm miss. LPM_SRC_LOOKUP is required"
+  },
+  //10
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "ipv6: lpm cached flow. LPM_SRC_LOOKUP is required"
+  },
+  //11
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::64", dst="fc00:1404::1")/UDP(sport=31337, dport=6080)/IP(src="192.168.1.3", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAADMRQAEAAAAAAAAAAAAAAAAAAGT8ABQEAAAAAAAAAAAAAAABemkXwAAzKZJFAAArAAEAAEARrU3AqAEDCsgBAXppAFAAF5fca2F0cmFuIHRlc3QgcGt0",
+    "gue ip4ip6 inline decap. INLINE_DECAP_GUE is required"
+  },
+  //12
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::64", dst="fc00:1404::1")/UDP(sport=31337, dport=6080)/IPv6(src="fc00:2307:1::2", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAAFMRQAEAAAAAAAAAAAAAAAAAAGT8ABQEAAAAAAAAAAAAAAABemkXwABT9XpgAAAAACMGQPwAIwcAAQAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "gue ip6ip6 inline decap. INLINE_DECAP_GUE is required"
+  },
+  //13
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::64", dst="fc00:1404::1")/IP(src="192.168.1.3", dst="10.200.1.1", ttl=1)/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAADMRQAEAAAAAAAAAAAAAAAAAAGT8ABQEAAAAAAAAAAAAAAABBTkXwAAznsJFAAArAAEAAAER7E3AqAEDCsgBAXppAFAAF5fca2F0cmFuIHRlc3QgcGt0",
+    "gue ip4ip6 inline decap ttl 1. INLINE_DECAP_GUE is required"
+  },
+  //14
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::64", dst="fc00:1404::1")/IPv6(src="fc00:2307:1::2", dst="fc00:1::1", hlim=1)/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAAFMRQAEAAAAAAAAAAAAAAAAAAGT8ABQEAAAAAAAAAAAAAAABBTkXwABTaupgAAAAACMGAfwAIwcAAQAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "gue ip6ip6 inline decap ttl 1. INLINE_DECAP_GUE is required"
+  },
+};
+
+const TestFixture outputGueOptionalTestFixtures = {
+  //1
+  {
+    "AQAAAAAAAgAAAAAACABFAABwAAAAAEABrRsKyAEBwKgBAQMEboQAAAXcRQAF+AABAABAEaeCwKgBAQrIAQF6aQBQBeToNmthdHJhbiB0ZXN0IHBrdGthdHJhbiB0ZXN0IHBrdGthdHJhbiB0ZXN0IHBrdGthdHJhbiB0ZXN0",
+    "XDP_TX"
+  },
+  //2
+  {
+    "AQAAAAAAAgAAAAAAht1gAAAAAQA6QPwAAAEAAAAAAAAAAAAAAAH8AAACAAAAAAAAAAAAAAABAgD3sgAABdxgAAAABfAGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAFN1AABrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdGVzdCBwa3RrYXRyYW4gdA==",
+    "XDP_TX"
+  },
+  //3
+  {
+    "AADerb6vAgAAAAAACABFAABHAAAAAEARWX8KAA0lCgAAA2h7F8AAMwAARQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //4
+  {
+    "AADerb6vAgAAAAAAht1gAAAAADMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwABe2sXwAAzAABFAAArAAEAAEARrU7AqAECCsgBAXppAFAAF5fda2F0cmFuIHRlc3QgcGt0",
+    "XDP_TX"
+  },
+  //5
+  {
+    "AADerb6vAgAAAAAAht1gAAAAADMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwACHmgXwAAzAABFAAArAAEAAEARSk/AqGQBCsgBAXppAFAAFzTea2F0cmFuIHRlc3QgcGt0",
+    "XDP_TX"
+  },
+  //6
+  {
+    "AADerb6vAgAAAAAACABFAABHAAAAAEARWX8KAA0lCgAAA6F7F8AAMwAARQAAKwABAABAEeZOwKjIAQrIAQF6aQBQABfQ3WthdHJhbiB0ZXN0IHBrdA==",
+    "XDP_TX"
+  },
+  //7
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwAQemkXwABTAABgAAAAACMGQPwAAAIAAAAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1OAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //8
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwAEemkXwABTAABgAAAAACMGQPwAIwcAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpKAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //9
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAABemkXwABTAABgAAAAACMGQPwAIwgAAQAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //10
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAADemkXwABTAABgAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //11
+  {
+    "AADerb6vAgAAAAAAht1gAAAAADMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwABe2oXwAAzAABFAAArAAEAAD8Rrk3AqAEDCsgBAXppAFAAF5fca2F0cmFuIHRlc3QgcGt0",
+    "XDP_TX"
+  },
+  //12
+  {
+    "AADerb6vAgAAAAAAht1gAAAAAFMRQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAjBwADemkXwABTAABgAAAAACMGP/wAIwcAAQAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_TX"
+  },
+  //13
+  {
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAAAR7E3AqAEDCsgBAXppAFAAF5fca2F0cmFuIHRlc3QgcGt0",
+    "XDP_DROP"
+  },
+  //14
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGAPwAIwcAAQAAAAAAAAAAAAL8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgANpIAABrYXRyYW4gdGVzdCBwa3Q=",
+    "XDP_DROP"
+  },
+};
+
+}
+}

--- a/katran/lib/testing/KatranGueTestFixtures.h
+++ b/katran/lib/testing/KatranGueTestFixtures.h
@@ -147,22 +147,22 @@ const std::vector<std::pair<std::string, std::string>> inputGueTestFixtures = {
   },
   //19
   {
-    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.4")/TCP(sport=31337, dport=42, flags="A")/"katran test pkt"
-    "AgAAAAAAAQAAAAAACABFAAA/AAEAAEAEvZesEAEBrBBkAUUAACsAAQAAQBGtT8CoAQEKyAEBemkAUAAXl95rYXRyYW4gdGVzdCBwa3Q=",
-    "ipinip packet"
+    //Ether(src="0x1", dst="0x2")/IP(src="172.16.1.1", dst="172.16.100.1")/UDP(sport=1337, dport=6080)/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAABHAAEAAEARvYKsEAEBrBBkAQU5F8AAM/MGRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "gue ipv4 inner ipv4 outer packet"
 
   },
   //20
   {
-    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
-    "AgAAAAAAAQAAAAAAht1gAAAAAEspQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACYAAAAAAjBkD8AAACAAAAAAAAAAAAAAAB/AAAAQAAAAAAAAAAAAAAAXppAFAAAAAAAAAAAFAQIAD9TwAAa2F0cmFuIHRlc3QgcGt0",
-    "ipv6inipv6 packet"
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/UDP(sport=1337, dport=6080)/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAAFMRQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACBTkXwABTehJgAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "gue ipv6 inner ipv6 outer packet"
   },
   //21
   {
-    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
-    "AgAAAAAAAQAAAAAAht1gAAAAACsEQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
-    "ipv4inipv6 packet"
+    //Ether(src="0x1", dst="0x2")/IPv6(src="100::1", dst="100::2")/UDP(sport=1337, dport=6080)/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAADMRQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACBTkXwAAzridFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
+    "gue ipv4 inner ipv6 outer packet"
   },
   //22
   {
@@ -230,7 +230,6 @@ const std::vector<std::pair<std::string, std::string>> inputGueTestFixtures = {
     "AgAAAAAAAQAAAAAAht1owAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
     "packet to TCP based v6 VIP (and v6 real) with ToS / tc set"
   },
-
 };
 
 const std::vector<std::pair<std::string, std::string>> outputGueTestFixtures = {
@@ -326,18 +325,18 @@ const std::vector<std::pair<std::string, std::string>> outputGueTestFixtures = {
   },
   //19
   {
-    "AgAAAAAAAQAAAAAACABFAAA/AAEAAEAEvZesEAEBrBBkAUUAACsAAQAAQBGtT8CoAQEKyAEBemkAUAAXl95rYXRyYW4gdGVzdCBwa3Q=",
+    "AgAAAAAAAQAAAAAACABFAABHAAEAAEARvYKsEAEBrBBkAQU5F8AAM/MGRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
     "XDP_PASS"
 
   },
   //20
   {
-    "AgAAAAAAAQAAAAAAht1gAAAAAEspQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACYAAAAAAjBkD8AAACAAAAAAAAAAAAAAAB/AAAAQAAAAAAAAAAAAAAAXppAFAAAAAAAAAAAFAQIAD9TwAAa2F0cmFuIHRlc3QgcGt0",
+    "AgAAAAAAAQAAAAAAht1gAAAAAFMRQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACBTkXwABTehJgAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
     "XDP_PASS"
   },
   //21
   {
-    "AgAAAAAAAQAAAAAAht1gAAAAACsEQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACRQAAKwABAABAEa1PwKgBAQrIAQF6aQBQABeX3mthdHJhbiB0ZXN0IHBrdA==",
+    "AgAAAAAAAQAAAAAAht1gAAAAADMRQAEAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAAAAAAAAACBTkXwAAzridFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
     "XDP_PASS"
   },
   //22

--- a/katran/lib/testing/katran_tester.cpp
+++ b/katran/lib/testing/katran_tester.cpp
@@ -25,10 +25,11 @@
 #include <folly/FileUtil.h>
 #include <gflags/gflags.h>
 
-#include "KatranOptionalTestFixtures.h"
-#include "KatranTestFixtures.h"
-#include "KatranGueTestFixtures.h"
-#include "XdpTester.h"
+#include "katran/lib/testing/KatranOptionalTestFixtures.h"
+#include "katran/lib/testing/KatranGueOptionalTestFixtures.h"
+#include "katran/lib/testing/KatranTestFixtures.h"
+#include "katran/lib/testing/KatranGueTestFixtures.h"
+#include "katran/lib/testing/XdpTester.h"
 #include "katran/lib/KatranLb.h"
 #include "katran/lib/KatranLbStructs.h"
 
@@ -441,9 +442,15 @@ int main(int argc, char** argv) {
       prepareOptionalLbData(lb);
       LOG(INFO) << "Running optional tests. they could fail if requirements "
                 << "are not satisfied";
+      if (FLAGS_gue) {
+      tester.resetTestFixtures(
+          katran::testing::inputGueOptionalTestFixtures,
+          katran::testing::outputGueOptionalTestFixtures);
+      } else {
       tester.resetTestFixtures(
           katran::testing::inputOptionalTestFixtures,
           katran::testing::outputOptionalTestFixtures);
+      }
       tester.testFromFixture();
       testOptionalLbCounters(lb);
     }


### PR DESCRIPTION
we want to be on for GUE w/ IPIP. in this diff i'm adding support
for GUE based decapsulation and making sure that features, like src
based routing (when we send packet to backend based on src ip address.
used in applications like stable/stabilized anycast
(https://landing.google.com/sre/workbook/chapters/managing-load/#stabilized-anycast))

there some added verbosity in defines dependency, but this is mostly for
not to break existing build (e.g. if someone is building katran prior
this diff w/ LPM_SRC_LOOKUP, he assumes that INLINE_DECAP would be
enabled as well w/o explicitly configureing INLINE_DECAP_IPIP).
happy to remove this complexity if you think that it acceptable to break
this builds.

also made sure that we could do both IPIP and GUE decaps at the same
time (e.g. for migration purpose. when katran could receive both GUE and
IPIP packets from remote side and decapsulate em for subsequent lookups;
to make migration to gue possible)

current size of bpf program when all the features are enabled
( ./build_bpf_modules_opensource.sh "-DICMP_TOOBIG_GENERATION
-DGUE_ENCAP -DINLINE_DECAP_GUE -DLPM_SRC_LOOKUP -DINLINE_DECAP_IPIP
-DKATRAN_INTROSPECTION")
is 2739 instructions

Tested-By: added new optional unittests for GUE