### PR TITLE
[katran]: sync up bpf headers w/ upstream

### DIFF
--- a/katran/lib/linux_includes/bpf.h
+++ b/katran/lib/linux_includes/bpf.h
@@ -14,6 +14,7 @@
 /* Extended instruction set based on top of classic BPF */
 
 /* instruction classes */
+#define BPF_JMP32 0x06  /* jmp mode in word width */
 #define BPF_ALU64 0x07  /* alu mode in double word width */
 
 /* ld/ldx fields */
@@ -103,6 +104,9 @@ enum bpf_cmd {
   BPF_BTF_LOAD,
   BPF_BTF_GET_FD_BY_ID,
   BPF_TASK_FD_QUERY,
+  BPF_MAP_LOOKUP_AND_DELETE_ELEM,
+  BPF_MAP_FREEZE,
+  BPF_BTF_GET_NEXT_ID,
 };
 
 enum bpf_map_type {
@@ -127,8 +131,21 @@ enum bpf_map_type {
   BPF_MAP_TYPE_SOCKHASH,
   BPF_MAP_TYPE_CGROUP_STORAGE,
   BPF_MAP_TYPE_REUSEPORT_SOCKARRAY,
+  BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE,
+  BPF_MAP_TYPE_QUEUE,
+  BPF_MAP_TYPE_STACK,
+  BPF_MAP_TYPE_SK_STORAGE,
+  BPF_MAP_TYPE_DEVMAP_HASH,
 };
 
+/* Note that tracing related programs such as
+ * BPF_PROG_TYPE_{KPROBE,TRACEPOINT,PERF_EVENT,RAW_TRACEPOINT}
+ * are not subject to a stable API since kernel internal data
+ * structures can change from release to release and may
+ * therefore break existing tracing BPF programs. Tracing BPF
+ * programs correspond to /a/ specific kernel which is to be
+ * analyzed, and not /a/ specific kernel /and/ all future ones.
+ */
 enum bpf_prog_type {
   BPF_PROG_TYPE_UNSPEC,
   BPF_PROG_TYPE_SOCKET_FILTER,
@@ -153,6 +170,10 @@ enum bpf_prog_type {
   BPF_PROG_TYPE_LIRC_MODE2,
   BPF_PROG_TYPE_SK_REUSEPORT,
   BPF_PROG_TYPE_FLOW_DISSECTOR,
+  BPF_PROG_TYPE_CGROUP_SYSCTL,
+  BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE,
+  BPF_PROG_TYPE_CGROUP_SOCKOPT,
+  BPF_PROG_TYPE_TRACING,
 };
 
 enum bpf_attach_type {
@@ -174,6 +195,14 @@ enum bpf_attach_type {
   BPF_CGROUP_UDP6_SENDMSG,
   BPF_LIRC_MODE2,
   BPF_FLOW_DISSECTOR,
+  BPF_CGROUP_SYSCTL,
+  BPF_CGROUP_UDP4_RECVMSG,
+  BPF_CGROUP_UDP6_RECVMSG,
+  BPF_CGROUP_GETSOCKOPT,
+  BPF_CGROUP_SETSOCKOPT,
+  BPF_TRACE_RAW_TP,
+  BPF_TRACE_FENTRY,
+  BPF_TRACE_FEXIT,
   __MAX_BPF_ATTACH_TYPE
 };
 
@@ -228,8 +257,54 @@ enum bpf_attach_type {
  */
 #define BPF_F_STRICT_ALIGNMENT  (1U << 0)
 
-/* when bpf_ldimm64->src_reg == BPF_PSEUDO_MAP_FD, bpf_ldimm64->imm == fd */
+/* If BPF_F_ANY_ALIGNMENT is used in BPF_PROF_LOAD command, the
+ * verifier will allow any alignment whatsoever.  On platforms
+ * with strict alignment requirements for loads ands stores (such
+ * as sparc and mips) the verifier validates that all loads and
+ * stores provably follow this requirement.  This flag turns that
+ * checking and enforcement off.
+ *
+ * It is mostly used for testing when we want to validate the
+ * context and memory access aspects of the verifier, but because
+ * of an unaligned access the alignment check would trigger before
+ * the one we are interested in.
+ */
+#define BPF_F_ANY_ALIGNMENT (1U << 1)
+
+/* BPF_F_TEST_RND_HI32 is used in BPF_PROG_LOAD command for testing purpose.
+ * Verifier does sub-register def/use analysis and identifies instructions whose
+ * def only matters for low 32-bit, high 32-bit is never referenced later
+ * through implicit zero extension. Therefore verifier notifies JIT back-ends
+ * that it is safe to ignore clearing high 32-bit for these instructions. This
+ * saves some back-ends a lot of code-gen. However such optimization is not
+ * necessary on some arches, for example x86_64, arm64 etc, whose JIT back-ends
+ * hence hasn't used verifier's analysis result. But, we really want to have a
+ * way to be able to verify the correctness of the described optimization on
+ * x86_64 on which testsuites are frequently exercised.
+ *
+ * So, this flag is introduced. Once it is set, verifier will randomize high
+ * 32-bit for those instructions who has been identified as safe to ignore them.
+ * Then, if verifier is not doing correct analysis, such randomization will
+ * regress tests to expose bugs.
+ */
+#define BPF_F_TEST_RND_HI32 (1U << 2)
+
+/* The verifier internal test flag. Behavior is undefined */
+#define BPF_F_TEST_STATE_FREQ (1U << 3)
+
+/* When BPF ldimm64's insn[0].src_reg != 0 then this can have
+ * two extensions:
+ *
+ * insn[0].src_reg:  BPF_PSEUDO_MAP_FD   BPF_PSEUDO_MAP_VALUE
+ * insn[0].imm:      map fd              map fd
+ * insn[1].imm:      0                   offset into value
+ * insn[0].off:      0                   0
+ * insn[1].off:      0                   0
+ * ldimm64 rewrite:  address of map      address of map[0]+offset
+ * verifier type:    CONST_PTR_TO_MAP    PTR_TO_MAP_VALUE
+ */
 #define BPF_PSEUDO_MAP_FD 1
+#define BPF_PSEUDO_MAP_VALUE  2
 
 /* when bpf_call->src_reg == BPF_PSEUDO_CALL, bpf_call->imm == pc-relative
  * offset to another bpf function
@@ -240,6 +315,7 @@ enum bpf_attach_type {
 #define BPF_ANY   0 /* create new element or update existing */
 #define BPF_NOEXIST 1 /* create new element if it didn't exist */
 #define BPF_EXIST 2 /* update existing element */
+#define BPF_F_LOCK  4 /* spin_lock-ed map_lookup/map_update */
 
 /* flags for BPF_MAP_CREATE command */
 #define BPF_F_NO_PREALLOC (1U << 0)
@@ -253,17 +329,30 @@ enum bpf_attach_type {
 /* Specify numa node during map creation */
 #define BPF_F_NUMA_NODE   (1U << 2)
 
-/* flags for BPF_PROG_QUERY */
-#define BPF_F_QUERY_EFFECTIVE (1U << 0)
-
 #define BPF_OBJ_NAME_LEN 16U
 
-/* Flags for accessing BPF object */
+/* Flags for accessing BPF object from syscall side. */
 #define BPF_F_RDONLY    (1U << 3)
 #define BPF_F_WRONLY    (1U << 4)
 
 /* Flag for stack_map, store build_id+offset instead of pointer */
 #define BPF_F_STACK_BUILD_ID  (1U << 5)
+
+/* Zero-initialize hash function seed. This should only be used for testing. */
+#define BPF_F_ZERO_SEED   (1U << 6)
+
+/* Flags for accessing BPF object from program side. */
+#define BPF_F_RDONLY_PROG (1U << 7)
+#define BPF_F_WRONLY_PROG (1U << 8)
+
+/* Clone map from listener for newly accepted socket */
+#define BPF_F_CLONE   (1U << 9)
+
+/* Enable memory-mapping BPF map */
+#define BPF_F_MMAPABLE    (1U << 10)
+
+/* flags for BPF_PROG_QUERY */
+#define BPF_F_QUERY_EFFECTIVE (1U << 0)
 
 enum bpf_stack_build_id_status {
   /* user space need an empty entry to identify end of a trace */
@@ -322,7 +411,7 @@ union bpf_attr {
     __u32   log_level;  /* verbosity level of verifier */
     __u32   log_size; /* size of user buffer */
     __aligned_u64 log_buf;  /* user supplied buffer */
-    __u32   kern_version; /* checked when prog_type=kprobe */
+    __u32   kern_version; /* not used */
     __u32   prog_flags;
     char    prog_name[BPF_OBJ_NAME_LEN];
     __u32   prog_ifindex; /* ifindex of netdev to prep for */
@@ -331,6 +420,15 @@ union bpf_attr {
      * (context accesses, allowed helpers, etc).
      */
     __u32   expected_attach_type;
+    __u32   prog_btf_fd;  /* fd pointing to BTF type data */
+    __u32   func_info_rec_size; /* userspace bpf_func_info size */
+    __aligned_u64 func_info;  /* func info */
+    __u32   func_info_cnt;  /* number of bpf_func_info records */
+    __u32   line_info_rec_size; /* userspace bpf_line_info size */
+    __aligned_u64 line_info;  /* line info */
+    __u32   line_info_cnt;  /* number of bpf_line_info records */
+    __u32   attach_btf_id;  /* in-kernel BTF type id to attach to */
+    __u32   attach_prog_fd; /* 0 to attach to vmlinux */
   };
 
   struct { /* anonymous struct used by BPF_OBJ_* commands */
@@ -349,12 +447,22 @@ union bpf_attr {
   struct { /* anonymous struct used by BPF_PROG_TEST_RUN command */
     __u32   prog_fd;
     __u32   retval;
-    __u32   data_size_in;
-    __u32   data_size_out;
+    __u32   data_size_in; /* input: len of data_in */
+    __u32   data_size_out;  /* input/output: len of data_out
+             *   returns ENOSPC if data_out
+             *   is too small.
+             */
     __aligned_u64 data_in;
     __aligned_u64 data_out;
     __u32   repeat;
     __u32   duration;
+    __u32   ctx_size_in;  /* input: len of ctx_in */
+    __u32   ctx_size_out; /* input/output: len of ctx_out
+             *   returns ENOSPC if ctx_out
+             *   is too small.
+             */
+    __aligned_u64 ctx_in;
+    __aligned_u64 ctx_out;
   } test;
 
   struct { /* anonymous struct used by BPF_*_GET_*_ID */
@@ -461,10 +569,13 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read(void *dst, u32 size, const void *src)
+ * int bpf_probe_read(void *dst, u32 size, const void *unsafe_ptr)
  *  Description
  *    For tracing programs, safely attempt to read *size* bytes from
- *    address *src* and store the data in *dst*.
+ *    kernel space address *unsafe_ptr* and store the data in *dst*.
+ *
+ *    Generally, use bpf_probe_read_user() or bpf_probe_read_kernel()
+ *    instead.
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
@@ -484,6 +595,8 @@ union bpf_attr {
  *    limited to five).
  *
  *    Each time the helper is called, it appends a line to the trace.
+ *    Lines are discarded while *\/sys/kernel/debug/tracing/trace* is
+ *    open, use *\/sys/kernel/debug/tracing/trace_pipe* to avoid this.
  *    The format of the trace is customizable, and the exact output
  *    one will get depends on the options set in
  *    *\/sys/kernel/debug/tracing/trace_options* (see also the
@@ -561,7 +674,7 @@ union bpf_attr {
  *    **BPF_F_INVALIDATE_HASH** (set *skb*\ **->hash**, *skb*\
  *    **->swhash** and *skb*\ **->l4hash** to 0).
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -586,7 +699,7 @@ union bpf_attr {
  *    flexibility and can handle sizes larger than 2 or 4 for the
  *    checksum to update.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -618,7 +731,7 @@ union bpf_attr {
  *    flexibility and can handle sizes larger than 2 or 4 for the
  *    checksum to update.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -673,7 +786,7 @@ union bpf_attr {
  *    efficient, but it is handled through an action code where the
  *    redirection happens only after the eBPF program has returned.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -693,7 +806,7 @@ union bpf_attr {
  *    A 64-bit integer containing the current GID and UID, and
  *    created as such: *current_gid* **<< 32 \|** *current_uid*.
  *
- * int bpf_get_current_comm(char *buf, u32 size_of_buf)
+ * int bpf_get_current_comm(void *buf, u32 size_of_buf)
  *  Description
  *    Copy the **comm** attribute of the current task into *buf* of
  *    *size_of_buf*. The **comm** attribute contains the name of
@@ -715,7 +828,7 @@ union bpf_attr {
  *    based on a user-provided identifier for all traffic coming from
  *    the tasks belonging to the related cgroup. See also the related
  *    kernel documentation, available from the Linux sources in file
- *    *Documentation/cgroup-v1/net_cls.txt*.
+ *    *Documentation/admin-guide/cgroup-v1/net_cls.rst*.
  *
  *    The Linux kernel has two versions for cgroups: there are
  *    cgroups v1 and cgroups v2. Both are available to users, who can
@@ -738,7 +851,7 @@ union bpf_attr {
  *    **ETH_P_8021Q** and **ETH_P_8021AD**, it is considered to
  *    be **ETH_P_8021Q**.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -750,7 +863,7 @@ union bpf_attr {
  *  Description
  *    Pop a VLAN header from the packet associated to *skb*.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -788,14 +901,14 @@ union bpf_attr {
  *
  *      int ret;
  *      struct bpf_tunnel_key key = {};
- *
+ *      
  *      ret = bpf_skb_get_tunnel_key(skb, &key, sizeof(key), 0);
  *      if (ret < 0)
  *        return TC_ACT_SHOT; // drop packet
- *
+ *      
  *      if (key.remote_ipv4 != 0x0a000001)
  *        return TC_ACT_SHOT; // drop packet
- *
+ *      
  *      return TC_ACT_OK;   // accept packet
  *
  *    This interface can also be used with all encapsulation devices
@@ -922,7 +1035,7 @@ union bpf_attr {
  *    The realm of the route for the packet associated to *skb*, or 0
  *    if none was found.
  *
- * int bpf_perf_event_output(struct pt_reg *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
+ * int bpf_perf_event_output(void *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
  *  Description
  *    Write raw *data* blob into a special BPF perf event held by
  *    *map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. This perf
@@ -967,7 +1080,7 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_load_bytes(const struct sk_buff *skb, u32 offset, void *to, u32 len)
+ * int bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32 len)
  *  Description
  *    This helper was provided as an easy way to load data from a
  *    packet. It can be used to load *len* bytes from *offset* from
@@ -984,7 +1097,7 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_get_stackid(struct pt_reg *ctx, struct bpf_map *map, u64 flags)
+ * int bpf_get_stackid(void *ctx, struct bpf_map *map, u64 flags)
  *  Description
  *    Walk a user or a kernel stack and return its id. To achieve
  *    this, the helper needs *ctx*, which is a pointer to the context
@@ -1053,7 +1166,7 @@ union bpf_attr {
  *    The checksum result, or a negative error code in case of
  *    failure.
  *
- * int bpf_skb_get_tunnel_opt(struct sk_buff *skb, u8 *opt, u32 size)
+ * int bpf_skb_get_tunnel_opt(struct sk_buff *skb, void *opt, u32 size)
  *  Description
  *    Retrieve tunnel options metadata for the packet associated to
  *    *skb*, and store the raw tunnel option data to the buffer *opt*
@@ -1071,7 +1184,7 @@ union bpf_attr {
  *  Return
  *    The size of the option data retrieved.
  *
- * int bpf_skb_set_tunnel_opt(struct sk_buff *skb, u8 *opt, u32 size)
+ * int bpf_skb_set_tunnel_opt(struct sk_buff *skb, void *opt, u32 size)
  *  Description
  *    Set tunnel options metadata for the packet associated to *skb*
  *    to the option data contained in the raw buffer *opt* of *size*.
@@ -1100,7 +1213,7 @@ union bpf_attr {
  *    All values for *flags* are reserved for future usage, and must
  *    be left at zero.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1213,7 +1326,7 @@ union bpf_attr {
  *    implicitly linearizes, unclones and drops offloads from the
  *    *skb*.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1249,7 +1362,7 @@ union bpf_attr {
  *    **bpf_skb_pull_data()** to effectively unclone the *skb* from
  *    the very beginning in case it is indeed cloned.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1301,7 +1414,7 @@ union bpf_attr {
  *    All values for *flags* are reserved for future usage, and must
  *    be left at zero.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1316,7 +1429,7 @@ union bpf_attr {
  *    can be used to prepare the packet for pushing or popping
  *    headers.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1324,45 +1437,14 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
+ * int bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)
  *  Description
- *    Copy a NUL terminated string from an unsafe address
- *    *unsafe_ptr* to *dst*. The *size* should include the
- *    terminating NUL byte. In case the string length is smaller than
- *    *size*, the target is not padded with further NUL bytes. If the
- *    string length is larger than *size*, just *size*-1 bytes are
- *    copied and the last byte is set to NUL.
+ *    Copy a NUL terminated string from an unsafe kernel address
+ *    *unsafe_ptr* to *dst*. See bpf_probe_read_kernel_str() for
+ *    more details.
  *
- *    On success, the length of the copied string is returned. This
- *    makes this helper useful in tracing programs for reading
- *    strings, and more importantly to get its length at runtime. See
- *    the following snippet:
- *
- *    ::
- *
- *      SEC("kprobe/sys_open")
- *      void bpf_sys_open(struct pt_regs *ctx)
- *      {
- *              char buf[PATHLEN]; // PATHLEN is defined to 256
- *              int res = bpf_probe_read_str(buf, sizeof(buf),
- *                                     ctx->di);
- *
- *        // Consume buf, for example push it to
- *        // userspace via bpf_perf_event_output(); we
- *        // can use res (the string length) as event
- *        // size, after checking its boundaries.
- *      }
- *
- *    In comparison, using **bpf_probe_read()** helper here instead
- *    to read the string would require to estimate the length at
- *    compile time, and would often result in copying more memory
- *    than necessary.
- *
- *    Another useful use case is when parsing individual process
- *    arguments or individual environment variables navigating
- *    *current*\ **->mm->arg_start** and *current*\
- *    **->mm->env_start**: using this helper and the return value,
- *    one can quickly iterate at the right offset of the memory area.
+ *    Generally, use bpf_probe_read_user_str() or bpf_probe_read_kernel_str()
+ *    instead.
  *  Return
  *    On success, the strictly positive length of the string,
  *    including the trailing NUL character. On error, a negative
@@ -1375,8 +1457,8 @@ union bpf_attr {
  *    If no cookie has been set yet, generate a new cookie. Once
  *    generated, the socket cookie remains stable for the life of the
  *    socket. This helper can be useful for monitoring per socket
- *    networking traffic statistics as it provides a unique socket
- *    identifier per namespace.
+ *    networking traffic statistics as it provides a global socket
+ *    identifier that can be assumed unique.
  *  Return
  *    A 8-byte long non-decreasing number on success, or 0 if the
  *    socket field is missing inside *skb*.
@@ -1384,14 +1466,14 @@ union bpf_attr {
  * u64 bpf_get_socket_cookie(struct bpf_sock_addr *ctx)
  *  Description
  *    Equivalent to bpf_get_socket_cookie() helper that accepts
- *    *skb*, but gets socket from **struct bpf_sock_addr** contex.
+ *    *skb*, but gets socket from **struct bpf_sock_addr** context.
  *  Return
  *    A 8-byte long non-decreasing number.
  *
  * u64 bpf_get_socket_cookie(struct bpf_sock_ops *ctx)
  *  Description
  *    Equivalent to bpf_get_socket_cookie() helper that accepts
- *    *skb*, but gets socket from **struct bpf_sock_ops** contex.
+ *    *skb*, but gets socket from **struct bpf_sock_ops** context.
  *  Return
  *    A 8-byte long non-decreasing number.
  *
@@ -1410,7 +1492,7 @@ union bpf_attr {
  *  Return
  *    0
  *
- * int bpf_setsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, char *optval, int optlen)
+ * int bpf_setsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, void *optval, int optlen)
  *  Description
  *    Emulate a call to **setsockopt()** on the socket associated to
  *    *bpf_socket*, which must be a full socket. The *level* at
@@ -1432,20 +1514,38 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_adjust_room(struct sk_buff *skb, u32 len_diff, u32 mode, u64 flags)
+ * int bpf_skb_adjust_room(struct sk_buff *skb, s32 len_diff, u32 mode, u64 flags)
  *  Description
  *    Grow or shrink the room for data in the packet associated to
  *    *skb* by *len_diff*, and according to the selected *mode*.
  *
- *    There is a single supported mode at this time:
+ *    There are two supported modes at this time:
+ *
+ *    * **BPF_ADJ_ROOM_MAC**: Adjust room at the mac layer
+ *      (room space is added or removed below the layer 2 header).
  *
  *    * **BPF_ADJ_ROOM_NET**: Adjust room at the network layer
  *      (room space is added or removed below the layer 3 header).
  *
- *    All values for *flags* are reserved for future usage, and must
- *    be left at zero.
+ *    The following flags are supported at this time:
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    * **BPF_F_ADJ_ROOM_FIXED_GSO**: Do not adjust gso_size.
+ *      Adjusting mss in this way is not allowed for datagrams.
+ *
+ *    * **BPF_F_ADJ_ROOM_ENCAP_L3_IPV4**,
+ *      **BPF_F_ADJ_ROOM_ENCAP_L3_IPV6**:
+ *      Any new space is reserved to hold a tunnel header.
+ *      Configure skb offsets and other fields accordingly.
+ *
+ *    * **BPF_F_ADJ_ROOM_ENCAP_L4_GRE**,
+ *      **BPF_F_ADJ_ROOM_ENCAP_L4_UDP**:
+ *      Use with ENCAP_L3 flags to further specify the tunnel type.
+ *
+ *    * **BPF_F_ADJ_ROOM_ENCAP_L2**\ (*len*):
+ *      Use with ENCAP_L3/L4 flags to further specify the tunnel
+ *      type; *len* is the length of the inner MAC header.
+ *
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1462,8 +1562,11 @@ union bpf_attr {
  *    but this is only implemented for native XDP (with driver
  *    support) as of this writing).
  *
- *    All values for *flags* are reserved for future usage, and must
- *    be left at zero.
+ *    The lower two bits of *flags* are used as the return code if
+ *    the map lookup fails. This is so that the return value can be
+ *    one of the XDP program return codes up to XDP_TX, as chosen by
+ *    the caller. Any higher bits in the *flags* argument must be
+ *    unset.
  *
  *    When used to redirect packets to net devices, this helper
  *    provides a high performance increase over **bpf_redirect**\ ().
@@ -1473,7 +1576,7 @@ union bpf_attr {
  *  Return
  *    **XDP_REDIRECT** on success, or **XDP_ABORTED** on error.
  *
- * int bpf_sk_redirect_map(struct bpf_map *map, u32 key, u64 flags)
+ * int bpf_sk_redirect_map(struct sk_buff *skb, struct bpf_map *map, u32 key, u64 flags)
  *  Description
  *    Redirect the packet to the socket referenced by *map* (of type
  *    **BPF_MAP_TYPE_SOCKMAP**) at index *key*. Both ingress and
@@ -1524,7 +1627,7 @@ union bpf_attr {
  *    more flexibility as the user is free to store whatever meta
  *    data they need.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1593,7 +1696,7 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_getsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, char *optval, int optlen)
+ * int bpf_getsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, void *optval, int optlen)
  *  Description
  *    Emulate a call to **getsockopt()** on the socket associated to
  *    *bpf_socket*, which must be a full socket. The *level* at
@@ -1612,7 +1715,7 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_override_return(struct pt_reg *regs, u64 rc)
+ * int bpf_override_return(struct pt_regs *regs, u64 rc)
  *  Description
  *    Used for error injection, this helper uses kprobes to override
  *    the return value of the probed function, and to set it to *rc*.
@@ -1653,11 +1756,19 @@ union bpf_attr {
  *    error if an eBPF program tries to set a callback that is not
  *    supported in the current kernel.
  *
- *    The supported callback values that *argval* can combine are:
+ *    *argval* is a flag array which can combine these flags:
  *
  *    * **BPF_SOCK_OPS_RTO_CB_FLAG** (retransmission time out)
  *    * **BPF_SOCK_OPS_RETRANS_CB_FLAG** (retransmission)
  *    * **BPF_SOCK_OPS_STATE_CB_FLAG** (TCP state change)
+ *    * **BPF_SOCK_OPS_RTT_CB_FLAG** (every RTT)
+ *
+ *    Therefore, this function can be used to clear a callback flag by
+ *    setting the appropriate bit to zero. e.g. to disable the RTO
+ *    callback:
+ *
+ *    **bpf_sock_ops_cb_flags_set(bpf_sock,**
+ *      **bpf_sock->bpf_sock_ops_cb_flags & ~BPF_SOCK_OPS_RTO_CB_FLAG)**
  *
  *    Here are some examples of where one could call such eBPF
  *    program:
@@ -1759,7 +1870,7 @@ union bpf_attr {
  *    copied if necessary (i.e. if data was not linear and if start
  *    and end pointers do not point to the same chunk).
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1793,7 +1904,7 @@ union bpf_attr {
  *    only possible to shrink the packet as of this writing,
  *    therefore *delta* must be a negative integer.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1817,7 +1928,7 @@ union bpf_attr {
  *  Return
  *    0 on success, or a negative error in case of failure.
  *
- * int bpf_get_stack(struct pt_regs *regs, void *buf, u32 size, u64 flags)
+ * int bpf_get_stack(void *ctx, void *buf, u32 size, u64 flags)
  *  Description
  *    Return a user or a kernel stack in bpf program provided buffer.
  *    To achieve this, the helper needs *ctx*, which is a pointer
@@ -1850,7 +1961,7 @@ union bpf_attr {
  *    A non-negative value equal to or less than *size* on success,
  *    or a negative error in case of failure.
  *
- * int bpf_skb_load_bytes_relative(const struct sk_buff *skb, u32 offset, void *to, u32 len, u32 start_header)
+ * int bpf_skb_load_bytes_relative(const void *skb, u32 offset, void *to, u32 len, u32 start_header)
  *  Description
  *    This helper is similar to **bpf_skb_load_bytes**\ () in that
  *    it provides an easy way to load *len* bytes from *offset*
@@ -1884,9 +1995,9 @@ union bpf_attr {
  *    is set to metric from route (IPv4/IPv6 only), and ifindex
  *    is set to the device index of the nexthop from the FIB lookup.
  *
- *             *plen* argument is the size of the passed in struct.
- *             *flags* argument can be a combination of one or more of the
- *             following values:
+ *    *plen* argument is the size of the passed in struct.
+ *    *flags* argument can be a combination of one or more of the
+ *    following values:
  *
  *    **BPF_FIB_LOOKUP_DIRECT**
  *      Do a direct table lookup vs full lookup using FIB
@@ -1895,15 +2006,15 @@ union bpf_attr {
  *      Perform lookup from an egress perspective (default is
  *      ingress).
  *
- *             *ctx* is either **struct xdp_md** for XDP programs or
- *             **struct sk_buff** tc cls_act programs.
- *     Return
+ *    *ctx* is either **struct xdp_md** for XDP programs or
+ *    **struct sk_buff** tc cls_act programs.
+ *  Return
  *    * < 0 if any input argument is invalid
  *    *   0 on success (packet is forwarded, nexthop neighbor exists)
  *    * > 0 one of **BPF_FIB_LKUP_RET_** codes explaining why the
  *      packet is not forwarded or needs assist from full stack
  *
- * int bpf_sock_hash_update(struct bpf_sock_ops_kern *skops, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_sock_hash_update(struct bpf_sock_ops *skops, struct bpf_map *map, void *key, u64 flags)
  *  Description
  *    Add an entry to, or update a sockhash *map* referencing sockets.
  *    The *skops* is used as a new value for the entry associated to
@@ -1965,8 +2076,21 @@ union bpf_attr {
  *      Only works if *skb* contains an IPv6 packet. Insert a
  *      Segment Routing Header (**struct ipv6_sr_hdr**) inside
  *      the IPv6 header.
+ *    **BPF_LWT_ENCAP_IP**
+ *      IP encapsulation (GRE/GUE/IPIP/etc). The outer header
+ *      must be IPv4 or IPv6, followed by zero or more
+ *      additional headers, up to **LWT_BPF_MAX_HEADROOM**
+ *      total bytes in all prepended headers. Please note that
+ *      if **skb_is_gso**\ (*skb*) is true, no more than two
+ *      headers can be prepended, and the inner header, if
+ *      present, should be either GRE or UDP/GUE.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    **BPF_LWT_ENCAP_SEG6**\ \* types can be called by BPF programs
+ *    of type **BPF_PROG_TYPE_LWT_IN**; **BPF_LWT_ENCAP_IP** type can
+ *    be called by bpf programs of types **BPF_PROG_TYPE_LWT_IN** and
+ *    **BPF_PROG_TYPE_LWT_XMIT**.
+ *
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1981,7 +2105,7 @@ union bpf_attr {
  *    inside the outermost IPv6 Segment Routing Header can be
  *    modified through this helper.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -1997,7 +2121,7 @@ union bpf_attr {
  *    after the segments are accepted. *delta* can be as well
  *    positive (growing) as negative (shrinking).
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
@@ -2020,45 +2144,19 @@ union bpf_attr {
  *      Type of *param*: **int**.
  *    **SEG6_LOCAL_ACTION_END_B6**
  *      End.B6 action: Endpoint bound to an SRv6 policy.
- *      Type of param: **struct ipv6_sr_hdr**.
+ *      Type of *param*: **struct ipv6_sr_hdr**.
  *    **SEG6_LOCAL_ACTION_END_B6_ENCAP**
  *      End.B6.Encap action: Endpoint bound to an SRv6
  *      encapsulation policy.
- *      Type of param: **struct ipv6_sr_hdr**.
+ *      Type of *param*: **struct ipv6_sr_hdr**.
  *
- *    A call to this helper is susceptible to change the underlaying
+ *    A call to this helper is susceptible to change the underlying
  *    packet buffer. Therefore, at load time, all checks on pointers
  *    previously done by the verifier are invalidated and must be
  *    performed again, if the helper is used in combination with
  *    direct packet access.
  *  Return
  *    0 on success, or a negative error in case of failure.
- *
- * int bpf_rc_keydown(void *ctx, u32 protocol, u64 scancode, u32 toggle)
- *  Description
- *    This helper is used in programs implementing IR decoding, to
- *    report a successfully decoded key press with *scancode*,
- *    *toggle* value in the given *protocol*. The scancode will be
- *    translated to a keycode using the rc keymap, and reported as
- *    an input key down event. After a period a key up event is
- *    generated. This period can be extended by calling either
- *    **bpf_rc_keydown** () again with the same values, or calling
- *    **bpf_rc_repeat** ().
- *
- *    Some protocols include a toggle bit, in case the button was
- *    released and pressed again between consecutive scancodes.
- *
- *    The *ctx* should point to the lirc sample as passed into
- *    the program.
- *
- *    The *protocol* is the decoded protocol number (see
- *    **enum rc_proto** for some predefined values).
- *
- *    This helper is only available is the kernel was compiled with
- *    the **CONFIG_BPF_LIRC_MODE2** configuration option set to
- *    "**y**".
- *  Return
- *    0
  *
  * int bpf_rc_repeat(void *ctx)
  *  Description
@@ -2079,7 +2177,33 @@ union bpf_attr {
  *  Return
  *    0
  *
- * uint64_t bpf_skb_cgroup_id(struct sk_buff *skb)
+ * int bpf_rc_keydown(void *ctx, u32 protocol, u64 scancode, u32 toggle)
+ *  Description
+ *    This helper is used in programs implementing IR decoding, to
+ *    report a successfully decoded key press with *scancode*,
+ *    *toggle* value in the given *protocol*. The scancode will be
+ *    translated to a keycode using the rc keymap, and reported as
+ *    an input key down event. After a period a key up event is
+ *    generated. This period can be extended by calling either
+ *    **bpf_rc_keydown**\ () again with the same values, or calling
+ *    **bpf_rc_repeat**\ ().
+ *
+ *    Some protocols include a toggle bit, in case the button was
+ *    released and pressed again between consecutive scancodes.
+ *
+ *    The *ctx* should point to the lirc sample as passed into
+ *    the program.
+ *
+ *    The *protocol* is the decoded protocol number (see
+ *    **enum rc_proto** for some predefined values).
+ *
+ *    This helper is only available is the kernel was compiled with
+ *    the **CONFIG_BPF_LIRC_MODE2** configuration option set to
+ *    "**y**".
+ *  Return
+ *    0
+ *
+ * u64 bpf_skb_cgroup_id(struct sk_buff *skb)
  *  Description
  *    Return the cgroup v2 id of the socket associated with the *skb*.
  *    This is roughly similar to the **bpf_get_cgroup_classid**\ ()
@@ -2094,6 +2218,38 @@ union bpf_attr {
  *    **CONFIG_SOCK_CGROUP_DATA** configuration option.
  *  Return
  *    The id is returned or 0 in case the id could not be retrieved.
+ *
+ * u64 bpf_get_current_cgroup_id(void)
+ *  Return
+ *    A 64-bit integer containing the current cgroup id based
+ *    on the cgroup within which the current task is running.
+ *
+ * void *bpf_get_local_storage(void *map, u64 flags)
+ *  Description
+ *    Get the pointer to the local storage area.
+ *    The type and the size of the local storage is defined
+ *    by the *map* argument.
+ *    The *flags* meaning is specific for each map type,
+ *    and has to be 0 for cgroup local storage.
+ *
+ *    Depending on the BPF program type, a local storage area
+ *    can be shared between multiple instances of the BPF program,
+ *    running simultaneously.
+ *
+ *    A user should care about the synchronization by himself.
+ *    For example, by using the **BPF_STX_XADD** instruction to alter
+ *    the shared data.
+ *  Return
+ *    A pointer to the local storage area.
+ *
+ * int bpf_sk_select_reuseport(struct sk_reuseport_md *reuse, struct bpf_map *map, void *key, u64 flags)
+ *  Description
+ *    Select a **SO_REUSEPORT** socket from a
+ *    **BPF_MAP_TYPE_REUSEPORT_ARRAY** *map*.
+ *    It checks the selected socket is matching the incoming
+ *    request in the socket buffer.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
  *
  * u64 bpf_skb_ancestor_cgroup_id(struct sk_buff *skb, int ancestor_level)
  *  Description
@@ -2113,36 +2269,558 @@ union bpf_attr {
  *  Return
  *    The id is returned or 0 in case the id could not be retrieved.
  *
- * u64 bpf_get_current_cgroup_id(void)
- *  Return
- *    A 64-bit integer containing the current cgroup id based
- *    on the cgroup within which the current task is running.
- *
- * void* get_local_storage(void *map, u64 flags)
+ * struct bpf_sock *bpf_sk_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
  *  Description
- *    Get the pointer to the local storage area.
- *    The type and the size of the local storage is defined
- *    by the *map* argument.
- *    The *flags* meaning is specific for each map type,
- *    and has to be 0 for cgroup local storage.
+ *    Look for TCP socket matching *tuple*, optionally in a child
+ *    network namespace *netns*. The return value must be checked,
+ *    and if non-**NULL**, released via **bpf_sk_release**\ ().
  *
- *    Depending on the bpf program type, a local storage area
- *    can be shared between multiple instances of the bpf program,
- *    running simultaneously.
+ *    The *ctx* should point to the context of the program, such as
+ *    the skb or socket (depending on the hook in use). This is used
+ *    to determine the base network namespace for the lookup.
  *
- *    A user should care about the synchronization by himself.
- *    For example, by using the BPF_STX_XADD instruction to alter
- *    the shared data.
+ *    *tuple_size* must be one of:
+ *
+ *    **sizeof**\ (*tuple*\ **->ipv4**)
+ *      Look for an IPv4 socket.
+ *    **sizeof**\ (*tuple*\ **->ipv6**)
+ *      Look for an IPv6 socket.
+ *
+ *    If the *netns* is a negative signed 32-bit integer, then the
+ *    socket lookup table in the netns associated with the *ctx* will
+ *    will be used. For the TC hooks, this is the netns of the device
+ *    in the skb. For socket hooks, this is the netns of the socket.
+ *    If *netns* is any other signed 32-bit value greater than or
+ *    equal to zero then it specifies the ID of the netns relative to
+ *    the netns associated with the *ctx*. *netns* values beyond the
+ *    range of 32-bit integers are reserved for future use.
+ *
+ *    All values for *flags* are reserved for future usage, and must
+ *    be left at zero.
+ *
+ *    This helper is available only if the kernel was compiled with
+ *    **CONFIG_NET** configuration option.
  *  Return
- *    Pointer to the local storage area.
+ *    Pointer to **struct bpf_sock**, or **NULL** in case of failure.
+ *    For sockets with reuseport option, the **struct bpf_sock**
+ *    result is from *reuse*\ **->socks**\ [] using the hash of the
+ *    tuple.
  *
- * int bpf_sk_select_reuseport(struct sk_reuseport_md *reuse, struct bpf_map *map, void *key, u64 flags)
+ * struct bpf_sock *bpf_sk_lookup_udp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
  *  Description
- *    Select a SO_REUSEPORT sk from a BPF_MAP_TYPE_REUSEPORT_ARRAY map
- *    It checks the selected sk is matching the incoming
- *    request in the skb.
+ *    Look for UDP socket matching *tuple*, optionally in a child
+ *    network namespace *netns*. The return value must be checked,
+ *    and if non-**NULL**, released via **bpf_sk_release**\ ().
+ *
+ *    The *ctx* should point to the context of the program, such as
+ *    the skb or socket (depending on the hook in use). This is used
+ *    to determine the base network namespace for the lookup.
+ *
+ *    *tuple_size* must be one of:
+ *
+ *    **sizeof**\ (*tuple*\ **->ipv4**)
+ *      Look for an IPv4 socket.
+ *    **sizeof**\ (*tuple*\ **->ipv6**)
+ *      Look for an IPv6 socket.
+ *
+ *    If the *netns* is a negative signed 32-bit integer, then the
+ *    socket lookup table in the netns associated with the *ctx* will
+ *    will be used. For the TC hooks, this is the netns of the device
+ *    in the skb. For socket hooks, this is the netns of the socket.
+ *    If *netns* is any other signed 32-bit value greater than or
+ *    equal to zero then it specifies the ID of the netns relative to
+ *    the netns associated with the *ctx*. *netns* values beyond the
+ *    range of 32-bit integers are reserved for future use.
+ *
+ *    All values for *flags* are reserved for future usage, and must
+ *    be left at zero.
+ *
+ *    This helper is available only if the kernel was compiled with
+ *    **CONFIG_NET** configuration option.
+ *  Return
+ *    Pointer to **struct bpf_sock**, or **NULL** in case of failure.
+ *    For sockets with reuseport option, the **struct bpf_sock**
+ *    result is from *reuse*\ **->socks**\ [] using the hash of the
+ *    tuple.
+ *
+ * int bpf_sk_release(struct bpf_sock *sock)
+ *  Description
+ *    Release the reference held by *sock*. *sock* must be a
+ *    non-**NULL** pointer that was returned from
+ *    **bpf_sk_lookup_xxx**\ ().
  *  Return
  *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_map_push_elem(struct bpf_map *map, const void *value, u64 flags)
+ *  Description
+ *    Push an element *value* in *map*. *flags* is one of:
+ *
+ *    **BPF_EXIST**
+ *      If the queue/stack is full, the oldest element is
+ *      removed to make room for this.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_map_pop_elem(struct bpf_map *map, void *value)
+ *  Description
+ *    Pop an element from *map*.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_map_peek_elem(struct bpf_map *map, void *value)
+ *  Description
+ *    Get an element from *map* without removing it.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_msg_push_data(struct sk_msg_buff *msg, u32 start, u32 len, u64 flags)
+ *  Description
+ *    For socket policies, insert *len* bytes into *msg* at offset
+ *    *start*.
+ *
+ *    If a program of type **BPF_PROG_TYPE_SK_MSG** is run on a
+ *    *msg* it may want to insert metadata or options into the *msg*.
+ *    This can later be read and used by any of the lower layer BPF
+ *    hooks.
+ *
+ *    This helper may fail if under memory pressure (a malloc
+ *    fails) in these cases BPF programs will get an appropriate
+ *    error and BPF programs will need to handle them.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_msg_pop_data(struct sk_msg_buff *msg, u32 start, u32 len, u64 flags)
+ *  Description
+ *    Will remove *len* bytes from a *msg* starting at byte *start*.
+ *    This may result in **ENOMEM** errors under certain situations if
+ *    an allocation and copy are required due to a full ring buffer.
+ *    However, the helper will try to avoid doing the allocation
+ *    if possible. Other errors can occur if input parameters are
+ *    invalid either due to *start* byte not being valid part of *msg*
+ *    payload and/or *pop* value being to large.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_rc_pointer_rel(void *ctx, s32 rel_x, s32 rel_y)
+ *  Description
+ *    This helper is used in programs implementing IR decoding, to
+ *    report a successfully decoded pointer movement.
+ *
+ *    The *ctx* should point to the lirc sample as passed into
+ *    the program.
+ *
+ *    This helper is only available is the kernel was compiled with
+ *    the **CONFIG_BPF_LIRC_MODE2** configuration option set to
+ *    "**y**".
+ *  Return
+ *    0
+ *
+ * int bpf_spin_lock(struct bpf_spin_lock *lock)
+ *  Description
+ *    Acquire a spinlock represented by the pointer *lock*, which is
+ *    stored as part of a value of a map. Taking the lock allows to
+ *    safely update the rest of the fields in that value. The
+ *    spinlock can (and must) later be released with a call to
+ *    **bpf_spin_unlock**\ (\ *lock*\ ).
+ *
+ *    Spinlocks in BPF programs come with a number of restrictions
+ *    and constraints:
+ *
+ *    * **bpf_spin_lock** objects are only allowed inside maps of
+ *      types **BPF_MAP_TYPE_HASH** and **BPF_MAP_TYPE_ARRAY** (this
+ *      list could be extended in the future).
+ *    * BTF description of the map is mandatory.
+ *    * The BPF program can take ONE lock at a time, since taking two
+ *      or more could cause dead locks.
+ *    * Only one **struct bpf_spin_lock** is allowed per map element.
+ *    * When the lock is taken, calls (either BPF to BPF or helpers)
+ *      are not allowed.
+ *    * The **BPF_LD_ABS** and **BPF_LD_IND** instructions are not
+ *      allowed inside a spinlock-ed region.
+ *    * The BPF program MUST call **bpf_spin_unlock**\ () to release
+ *      the lock, on all execution paths, before it returns.
+ *    * The BPF program can access **struct bpf_spin_lock** only via
+ *      the **bpf_spin_lock**\ () and **bpf_spin_unlock**\ ()
+ *      helpers. Loading or storing data into the **struct
+ *      bpf_spin_lock** *lock*\ **;** field of a map is not allowed.
+ *    * To use the **bpf_spin_lock**\ () helper, the BTF description
+ *      of the map value must be a struct and have **struct
+ *      bpf_spin_lock** *anyname*\ **;** field at the top level.
+ *      Nested lock inside another struct is not allowed.
+ *    * The **struct bpf_spin_lock** *lock* field in a map value must
+ *      be aligned on a multiple of 4 bytes in that value.
+ *    * Syscall with command **BPF_MAP_LOOKUP_ELEM** does not copy
+ *      the **bpf_spin_lock** field to user space.
+ *    * Syscall with command **BPF_MAP_UPDATE_ELEM**, or update from
+ *      a BPF program, do not update the **bpf_spin_lock** field.
+ *    * **bpf_spin_lock** cannot be on the stack or inside a
+ *      networking packet (it can only be inside of a map values).
+ *    * **bpf_spin_lock** is available to root only.
+ *    * Tracing programs and socket filter programs cannot use
+ *      **bpf_spin_lock**\ () due to insufficient preemption checks
+ *      (but this may change in the future).
+ *    * **bpf_spin_lock** is not allowed in inner maps of map-in-map.
+ *  Return
+ *    0
+ *
+ * int bpf_spin_unlock(struct bpf_spin_lock *lock)
+ *  Description
+ *    Release the *lock* previously locked by a call to
+ *    **bpf_spin_lock**\ (\ *lock*\ ).
+ *  Return
+ *    0
+ *
+ * struct bpf_sock *bpf_sk_fullsock(struct bpf_sock *sk)
+ *  Description
+ *    This helper gets a **struct bpf_sock** pointer such
+ *    that all the fields in this **bpf_sock** can be accessed.
+ *  Return
+ *    A **struct bpf_sock** pointer on success, or **NULL** in
+ *    case of failure.
+ *
+ * struct bpf_tcp_sock *bpf_tcp_sock(struct bpf_sock *sk)
+ *  Description
+ *    This helper gets a **struct bpf_tcp_sock** pointer from a
+ *    **struct bpf_sock** pointer.
+ *  Return
+ *    A **struct bpf_tcp_sock** pointer on success, or **NULL** in
+ *    case of failure.
+ *
+ * int bpf_skb_ecn_set_ce(struct sk_buff *skb)
+ *  Description
+ *    Set ECN (Explicit Congestion Notification) field of IP header
+ *    to **CE** (Congestion Encountered) if current value is **ECT**
+ *    (ECN Capable Transport). Otherwise, do nothing. Works with IPv6
+ *    and IPv4.
+ *  Return
+ *    1 if the **CE** flag is set (either by the current helper call
+ *    or because it was already present), 0 if it is not set.
+ *
+ * struct bpf_sock *bpf_get_listener_sock(struct bpf_sock *sk)
+ *  Description
+ *    Return a **struct bpf_sock** pointer in **TCP_LISTEN** state.
+ *    **bpf_sk_release**\ () is unnecessary and not allowed.
+ *  Return
+ *    A **struct bpf_sock** pointer on success, or **NULL** in
+ *    case of failure.
+ *
+ * struct bpf_sock *bpf_skc_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
+ *  Description
+ *    Look for TCP socket matching *tuple*, optionally in a child
+ *    network namespace *netns*. The return value must be checked,
+ *    and if non-**NULL**, released via **bpf_sk_release**\ ().
+ *
+ *    This function is identical to **bpf_sk_lookup_tcp**\ (), except
+ *    that it also returns timewait or request sockets. Use
+ *    **bpf_sk_fullsock**\ () or **bpf_tcp_sock**\ () to access the
+ *    full structure.
+ *
+ *    This helper is available only if the kernel was compiled with
+ *    **CONFIG_NET** configuration option.
+ *  Return
+ *    Pointer to **struct bpf_sock**, or **NULL** in case of failure.
+ *    For sockets with reuseport option, the **struct bpf_sock**
+ *    result is from *reuse*\ **->socks**\ [] using the hash of the
+ *    tuple.
+ *
+ * int bpf_tcp_check_syncookie(struct bpf_sock *sk, void *iph, u32 iph_len, struct tcphdr *th, u32 th_len)
+ *  Description
+ *    Check whether *iph* and *th* contain a valid SYN cookie ACK for
+ *    the listening socket in *sk*.
+ *
+ *    *iph* points to the start of the IPv4 or IPv6 header, while
+ *    *iph_len* contains **sizeof**\ (**struct iphdr**) or
+ *    **sizeof**\ (**struct ip6hdr**).
+ *
+ *    *th* points to the start of the TCP header, while *th_len*
+ *    contains **sizeof**\ (**struct tcphdr**).
+ *
+ *  Return
+ *    0 if *iph* and *th* are a valid SYN cookie ACK, or a negative
+ *    error otherwise.
+ *
+ * int bpf_sysctl_get_name(struct bpf_sysctl *ctx, char *buf, size_t buf_len, u64 flags)
+ *  Description
+ *    Get name of sysctl in /proc/sys/ and copy it into provided by
+ *    program buffer *buf* of size *buf_len*.
+ *
+ *    The buffer is always NUL terminated, unless it's zero-sized.
+ *
+ *    If *flags* is zero, full name (e.g. "net/ipv4/tcp_mem") is
+ *    copied. Use **BPF_F_SYSCTL_BASE_NAME** flag to copy base name
+ *    only (e.g. "tcp_mem").
+ *  Return
+ *    Number of character copied (not including the trailing NUL).
+ *
+ *    **-E2BIG** if the buffer wasn't big enough (*buf* will contain
+ *    truncated name in this case).
+ *
+ * int bpf_sysctl_get_current_value(struct bpf_sysctl *ctx, char *buf, size_t buf_len)
+ *  Description
+ *    Get current value of sysctl as it is presented in /proc/sys
+ *    (incl. newline, etc), and copy it as a string into provided
+ *    by program buffer *buf* of size *buf_len*.
+ *
+ *    The whole value is copied, no matter what file position user
+ *    space issued e.g. sys_read at.
+ *
+ *    The buffer is always NUL terminated, unless it's zero-sized.
+ *  Return
+ *    Number of character copied (not including the trailing NUL).
+ *
+ *    **-E2BIG** if the buffer wasn't big enough (*buf* will contain
+ *    truncated name in this case).
+ *
+ *    **-EINVAL** if current value was unavailable, e.g. because
+ *    sysctl is uninitialized and read returns -EIO for it.
+ *
+ * int bpf_sysctl_get_new_value(struct bpf_sysctl *ctx, char *buf, size_t buf_len)
+ *  Description
+ *    Get new value being written by user space to sysctl (before
+ *    the actual write happens) and copy it as a string into
+ *    provided by program buffer *buf* of size *buf_len*.
+ *
+ *    User space may write new value at file position > 0.
+ *
+ *    The buffer is always NUL terminated, unless it's zero-sized.
+ *  Return
+ *    Number of character copied (not including the trailing NUL).
+ *
+ *    **-E2BIG** if the buffer wasn't big enough (*buf* will contain
+ *    truncated name in this case).
+ *
+ *    **-EINVAL** if sysctl is being read.
+ *
+ * int bpf_sysctl_set_new_value(struct bpf_sysctl *ctx, const char *buf, size_t buf_len)
+ *  Description
+ *    Override new value being written by user space to sysctl with
+ *    value provided by program in buffer *buf* of size *buf_len*.
+ *
+ *    *buf* should contain a string in same form as provided by user
+ *    space on sysctl write.
+ *
+ *    User space may write new value at file position > 0. To override
+ *    the whole sysctl value file position should be set to zero.
+ *  Return
+ *    0 on success.
+ *
+ *    **-E2BIG** if the *buf_len* is too big.
+ *
+ *    **-EINVAL** if sysctl is being read.
+ *
+ * int bpf_strtol(const char *buf, size_t buf_len, u64 flags, long *res)
+ *  Description
+ *    Convert the initial part of the string from buffer *buf* of
+ *    size *buf_len* to a long integer according to the given base
+ *    and save the result in *res*.
+ *
+ *    The string may begin with an arbitrary amount of white space
+ *    (as determined by **isspace**\ (3)) followed by a single
+ *    optional '**-**' sign.
+ *
+ *    Five least significant bits of *flags* encode base, other bits
+ *    are currently unused.
+ *
+ *    Base must be either 8, 10, 16 or 0 to detect it automatically
+ *    similar to user space **strtol**\ (3).
+ *  Return
+ *    Number of characters consumed on success. Must be positive but
+ *    no more than *buf_len*.
+ *
+ *    **-EINVAL** if no valid digits were found or unsupported base
+ *    was provided.
+ *
+ *    **-ERANGE** if resulting value was out of range.
+ *
+ * int bpf_strtoul(const char *buf, size_t buf_len, u64 flags, unsigned long *res)
+ *  Description
+ *    Convert the initial part of the string from buffer *buf* of
+ *    size *buf_len* to an unsigned long integer according to the
+ *    given base and save the result in *res*.
+ *
+ *    The string may begin with an arbitrary amount of white space
+ *    (as determined by **isspace**\ (3)).
+ *
+ *    Five least significant bits of *flags* encode base, other bits
+ *    are currently unused.
+ *
+ *    Base must be either 8, 10, 16 or 0 to detect it automatically
+ *    similar to user space **strtoul**\ (3).
+ *  Return
+ *    Number of characters consumed on success. Must be positive but
+ *    no more than *buf_len*.
+ *
+ *    **-EINVAL** if no valid digits were found or unsupported base
+ *    was provided.
+ *
+ *    **-ERANGE** if resulting value was out of range.
+ *
+ * void *bpf_sk_storage_get(struct bpf_map *map, struct bpf_sock *sk, void *value, u64 flags)
+ *  Description
+ *    Get a bpf-local-storage from a *sk*.
+ *
+ *    Logically, it could be thought of getting the value from
+ *    a *map* with *sk* as the **key**.  From this
+ *    perspective,  the usage is not much different from
+ *    **bpf_map_lookup_elem**\ (*map*, **&**\ *sk*) except this
+ *    helper enforces the key must be a full socket and the map must
+ *    be a **BPF_MAP_TYPE_SK_STORAGE** also.
+ *
+ *    Underneath, the value is stored locally at *sk* instead of
+ *    the *map*.  The *map* is used as the bpf-local-storage
+ *    "type". The bpf-local-storage "type" (i.e. the *map*) is
+ *    searched against all bpf-local-storages residing at *sk*.
+ *
+ *    An optional *flags* (**BPF_SK_STORAGE_GET_F_CREATE**) can be
+ *    used such that a new bpf-local-storage will be
+ *    created if one does not exist.  *value* can be used
+ *    together with **BPF_SK_STORAGE_GET_F_CREATE** to specify
+ *    the initial value of a bpf-local-storage.  If *value* is
+ *    **NULL**, the new bpf-local-storage will be zero initialized.
+ *  Return
+ *    A bpf-local-storage pointer is returned on success.
+ *
+ *    **NULL** if not found or there was an error in adding
+ *    a new bpf-local-storage.
+ *
+ * int bpf_sk_storage_delete(struct bpf_map *map, struct bpf_sock *sk)
+ *  Description
+ *    Delete a bpf-local-storage from a *sk*.
+ *  Return
+ *    0 on success.
+ *
+ *    **-ENOENT** if the bpf-local-storage cannot be found.
+ *
+ * int bpf_send_signal(u32 sig)
+ *  Description
+ *    Send signal *sig* to the current task.
+ *  Return
+ *    0 on success or successfully queued.
+ *
+ *    **-EBUSY** if work queue under nmi is full.
+ *
+ *    **-EINVAL** if *sig* is invalid.
+ *
+ *    **-EPERM** if no permission to send the *sig*.
+ *
+ *    **-EAGAIN** if bpf program can try again.
+ *
+ * s64 bpf_tcp_gen_syncookie(struct bpf_sock *sk, void *iph, u32 iph_len, struct tcphdr *th, u32 th_len)
+ *  Description
+ *    Try to issue a SYN cookie for the packet with corresponding
+ *    IP/TCP headers, *iph* and *th*, on the listening socket in *sk*.
+ *
+ *    *iph* points to the start of the IPv4 or IPv6 header, while
+ *    *iph_len* contains **sizeof**\ (**struct iphdr**) or
+ *    **sizeof**\ (**struct ip6hdr**).
+ *
+ *    *th* points to the start of the TCP header, while *th_len*
+ *    contains the length of the TCP header.
+ *
+ *  Return
+ *    On success, lower 32 bits hold the generated SYN cookie in
+ *    followed by 16 bits which hold the MSS value for that cookie,
+ *    and the top 16 bits are unused.
+ *
+ *    On failure, the returned value is one of the following:
+ *
+ *    **-EINVAL** SYN cookie cannot be issued due to error
+ *
+ *    **-ENOENT** SYN cookie should not be issued (no SYN flood)
+ *
+ *    **-EOPNOTSUPP** kernel configuration does not enable SYN cookies
+ *
+ *    **-EPROTONOSUPPORT** IP packet version is not 4 or 6
+ *
+ * int bpf_skb_output(void *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
+ *  Description
+ *    Write raw *data* blob into a special BPF perf event held by
+ *    *map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. This perf
+ *    event must have the following attributes: **PERF_SAMPLE_RAW**
+ *    as **sample_type**, **PERF_TYPE_SOFTWARE** as **type**, and
+ *    **PERF_COUNT_SW_BPF_OUTPUT** as **config**.
+ *
+ *    The *flags* are used to indicate the index in *map* for which
+ *    the value must be put, masked with **BPF_F_INDEX_MASK**.
+ *    Alternatively, *flags* can be set to **BPF_F_CURRENT_CPU**
+ *    to indicate that the index of the current CPU core should be
+ *    used.
+ *
+ *    The value to write, of *size*, is passed through eBPF stack and
+ *    pointed by *data*.
+ *
+ *    *ctx* is a pointer to in-kernel struct sk_buff.
+ *
+ *    This helper is similar to **bpf_perf_event_output**\ () but
+ *    restricted to raw_tracepoint bpf programs.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_probe_read_user(void *dst, u32 size, const void *unsafe_ptr)
+ *  Description
+ *    Safely attempt to read *size* bytes from user space address
+ *    *unsafe_ptr* and store the data in *dst*.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_probe_read_kernel(void *dst, u32 size, const void *unsafe_ptr)
+ *  Description
+ *    Safely attempt to read *size* bytes from kernel space address
+ *    *unsafe_ptr* and store the data in *dst*.
+ *  Return
+ *    0 on success, or a negative error in case of failure.
+ *
+ * int bpf_probe_read_user_str(void *dst, u32 size, const void *unsafe_ptr)
+ *  Description
+ *    Copy a NUL terminated string from an unsafe user address
+ *    *unsafe_ptr* to *dst*. The *size* should include the
+ *    terminating NUL byte. In case the string length is smaller than
+ *    *size*, the target is not padded with further NUL bytes. If the
+ *    string length is larger than *size*, just *size*-1 bytes are
+ *    copied and the last byte is set to NUL.
+ *
+ *    On success, the length of the copied string is returned. This
+ *    makes this helper useful in tracing programs for reading
+ *    strings, and more importantly to get its length at runtime. See
+ *    the following snippet:
+ *
+ *    ::
+ *
+ *      SEC("kprobe/sys_open")
+ *      void bpf_sys_open(struct pt_regs *ctx)
+ *      {
+ *              char buf[PATHLEN]; // PATHLEN is defined to 256
+ *              int res = bpf_probe_read_user_str(buf, sizeof(buf),
+ *                                          ctx->di);
+ *
+ *        // Consume buf, for example push it to
+ *        // userspace via bpf_perf_event_output(); we
+ *        // can use res (the string length) as event
+ *        // size, after checking its boundaries.
+ *      }
+ *
+ *    In comparison, using **bpf_probe_read_user()** helper here
+ *    instead to read the string would require to estimate the length
+ *    at compile time, and would often result in copying more memory
+ *    than necessary.
+ *
+ *    Another useful use case is when parsing individual process
+ *    arguments or individual environment variables navigating
+ *    *current*\ **->mm->arg_start** and *current*\
+ *    **->mm->env_start**: using this helper and the return value,
+ *    one can quickly iterate at the right offset of the memory area.
+ *  Return
+ *    On success, the strictly positive length of the string,
+ *    including the trailing NUL character. On error, a negative
+ *    value.
+ *
+ * int bpf_probe_read_kernel_str(void *dst, u32 size, const void *unsafe_ptr)
+ *  Description
+ *    Copy a NUL terminated string from an unsafe kernel address *unsafe_ptr*
+ *    to *dst*. Same semantics as with bpf_probe_read_user_str() apply.
+ *  Return
+ *    On success, the strictly positive length of the string, including
+ *    the trailing NUL character. On error, a negative value.
  */
 #define __BPF_FUNC_MAPPER(FN)   \
   FN(unspec),     \
@@ -2228,7 +2906,39 @@ union bpf_attr {
   FN(get_current_cgroup_id),  \
   FN(get_local_storage),    \
   FN(sk_select_reuseport),  \
-  FN(skb_ancestor_cgroup_id),
+  FN(skb_ancestor_cgroup_id), \
+  FN(sk_lookup_tcp),    \
+  FN(sk_lookup_udp),    \
+  FN(sk_release),     \
+  FN(map_push_elem),    \
+  FN(map_pop_elem),   \
+  FN(map_peek_elem),    \
+  FN(msg_push_data),    \
+  FN(msg_pop_data),   \
+  FN(rc_pointer_rel),   \
+  FN(spin_lock),      \
+  FN(spin_unlock),    \
+  FN(sk_fullsock),    \
+  FN(tcp_sock),     \
+  FN(skb_ecn_set_ce),   \
+  FN(get_listener_sock),    \
+  FN(skc_lookup_tcp),   \
+  FN(tcp_check_syncookie),  \
+  FN(sysctl_get_name),    \
+  FN(sysctl_get_current_value), \
+  FN(sysctl_get_new_value), \
+  FN(sysctl_set_new_value), \
+  FN(strtol),     \
+  FN(strtoul),      \
+  FN(sk_storage_get),   \
+  FN(sk_storage_delete),    \
+  FN(send_signal),    \
+  FN(tcp_gen_syncookie),    \
+  FN(skb_output),     \
+  FN(probe_read_user),    \
+  FN(probe_read_kernel),    \
+  FN(probe_read_user_str),  \
+  FN(probe_read_kernel_str),
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper
  * function eBPF program intends to call
@@ -2284,9 +2994,33 @@ enum bpf_func_id {
 /* BPF_FUNC_perf_event_output for sk_buff input context. */
 #define BPF_F_CTXLEN_MASK   (0xfffffULL << 32)
 
+/* Current network namespace */
+#define BPF_F_CURRENT_NETNS   (-1L)
+
+/* BPF_FUNC_skb_adjust_room flags. */
+#define BPF_F_ADJ_ROOM_FIXED_GSO  (1ULL << 0)
+
+#define BPF_ADJ_ROOM_ENCAP_L2_MASK  0xff
+#define BPF_ADJ_ROOM_ENCAP_L2_SHIFT 56
+
+#define BPF_F_ADJ_ROOM_ENCAP_L3_IPV4  (1ULL << 1)
+#define BPF_F_ADJ_ROOM_ENCAP_L3_IPV6  (1ULL << 2)
+#define BPF_F_ADJ_ROOM_ENCAP_L4_GRE (1ULL << 3)
+#define BPF_F_ADJ_ROOM_ENCAP_L4_UDP (1ULL << 4)
+#define BPF_F_ADJ_ROOM_ENCAP_L2(len)  (((__u64)len & \
+            BPF_ADJ_ROOM_ENCAP_L2_MASK) \
+           << BPF_ADJ_ROOM_ENCAP_L2_SHIFT)
+
+/* BPF_FUNC_sysctl_get_name flags. */
+#define BPF_F_SYSCTL_BASE_NAME    (1ULL << 0)
+
+/* BPF_FUNC_sk_storage_get flags */
+#define BPF_SK_STORAGE_GET_F_CREATE (1ULL << 0)
+
 /* Mode for BPF_FUNC_skb_adjust_room helper. */
 enum bpf_adj_room_mode {
   BPF_ADJ_ROOM_NET,
+  BPF_ADJ_ROOM_MAC,
 };
 
 /* Mode for BPF_FUNC_skb_load_bytes_relative helper. */
@@ -2298,8 +3032,15 @@ enum bpf_hdr_start_off {
 /* Encapsulation type for BPF_FUNC_lwt_push_encap helper. */
 enum bpf_lwt_encap_mode {
   BPF_LWT_ENCAP_SEG6,
-  BPF_LWT_ENCAP_SEG6_INLINE
+  BPF_LWT_ENCAP_SEG6_INLINE,
+  BPF_LWT_ENCAP_IP,
 };
+
+#define __bpf_md_ptr(type, name)  \
+union {         \
+  type name;      \
+  __u64 :64;      \
+} __attribute__((aligned(8)))
 
 /* user accessible mirror of in-kernel sk_buff.
  * new fields can only be added to the end of this structure
@@ -2335,7 +3076,11 @@ struct __sk_buff {
   /* ... here. */
 
   __u32 data_meta;
-  struct bpf_flow_keys *flow_keys;
+  __bpf_md_ptr(struct bpf_flow_keys *, flow_keys);
+  __u64 tstamp;
+  __u32 wire_len;
+  __u32 gso_segs;
+  __bpf_md_ptr(struct bpf_sock *, sk);
 };
 
 struct bpf_tunnel_key {
@@ -2377,7 +3122,15 @@ enum bpf_ret_code {
   BPF_DROP = 2,
   /* 3-6 reserved */
   BPF_REDIRECT = 7,
-  /* >127 are reserved for prog type specific return codes */
+  /* >127 are reserved for prog type specific return codes.
+   *
+   * BPF_LWT_REROUTE: used by BPF_PROG_TYPE_LWT_IN and
+   *    BPF_PROG_TYPE_LWT_XMIT to indicate that skb had been
+   *    changed and should be routed based on its new L3 header.
+   *    (This is an L3 redirect, as opposed to L2 redirect
+   *    represented by BPF_REDIRECT above).
+   */
+  BPF_LWT_REROUTE = 128,
 };
 
 struct bpf_sock {
@@ -2387,15 +3140,80 @@ struct bpf_sock {
   __u32 protocol;
   __u32 mark;
   __u32 priority;
-  __u32 src_ip4;    /* Allows 1,2,4-byte read.
-         * Stored in network byte order.
+  /* IP address also allows 1 and 2 bytes access */
+  __u32 src_ip4;
+  __u32 src_ip6[4];
+  __u32 src_port;   /* host byte order */
+  __u32 dst_port;   /* network byte order */
+  __u32 dst_ip4;
+  __u32 dst_ip6[4];
+  __u32 state;
+};
+
+struct bpf_tcp_sock {
+  __u32 snd_cwnd;   /* Sending congestion window    */
+  __u32 srtt_us;    /* smoothed round trip time << 3 in usecs */
+  __u32 rtt_min;
+  __u32 snd_ssthresh; /* Slow start size threshold    */
+  __u32 rcv_nxt;    /* What we want to receive next   */
+  __u32 snd_nxt;    /* Next sequence we send    */
+  __u32 snd_una;    /* First byte we want an ack for  */
+  __u32 mss_cache;  /* Cached effective mss, not including SACKS */
+  __u32 ecn_flags;  /* ECN status bits.     */
+  __u32 rate_delivered; /* saved rate sample: packets delivered */
+  __u32 rate_interval_us; /* saved rate sample: time elapsed */
+  __u32 packets_out;  /* Packets which are "in flight"  */
+  __u32 retrans_out;  /* Retransmitted packets out    */
+  __u32 total_retrans;  /* Total retransmits for entire connection */
+  __u32 segs_in;    /* RFC4898 tcpEStatsPerfSegsIn
+         * total number of segments in.
          */
-  __u32 src_ip6[4]; /* Allows 1,2,4-byte read.
-         * Stored in network byte order.
+  __u32 data_segs_in; /* RFC4898 tcpEStatsPerfDataSegsIn
+         * total number of data segments in.
          */
-  __u32 src_port;   /* Allows 4-byte read.
-         * Stored in host byte order
+  __u32 segs_out;   /* RFC4898 tcpEStatsPerfSegsOut
+         * The total number of segments sent.
          */
+  __u32 data_segs_out;  /* RFC4898 tcpEStatsPerfDataSegsOut
+         * total number of data segments sent.
+         */
+  __u32 lost_out;   /* Lost packets     */
+  __u32 sacked_out; /* SACK'd packets     */
+  __u64 bytes_received; /* RFC4898 tcpEStatsAppHCThruOctetsReceived
+         * sum(delta(rcv_nxt)), or how many bytes
+         * were acked.
+         */
+  __u64 bytes_acked;  /* RFC4898 tcpEStatsAppHCThruOctetsAcked
+         * sum(delta(snd_una)), or how many bytes
+         * were acked.
+         */
+  __u32 dsack_dups; /* RFC4898 tcpEStatsStackDSACKDups
+         * total number of DSACK blocks received
+         */
+  __u32 delivered;  /* Total data packets delivered incl. rexmits */
+  __u32 delivered_ce; /* Like the above but only ECE marked packets */
+  __u32 icsk_retransmits; /* Number of unrecovered [RTO] timeouts */
+};
+
+struct bpf_sock_tuple {
+  union {
+    struct {
+      __be32 saddr;
+      __be32 daddr;
+      __be16 sport;
+      __be16 dport;
+    } ipv4;
+    struct {
+      __be32 saddr[4];
+      __be32 daddr[4];
+      __be16 sport;
+      __be16 dport;
+    } ipv6;
+  };
+};
+
+struct bpf_xdp_sock {
+  __u32 queue_id;
 };
 
 #define XDP_PACKET_HEADROOM 256
@@ -2434,8 +3252,8 @@ enum sk_action {
  * be added to the end of this structure
  */
 struct sk_msg_md {
-  void *data;
-  void *data_end;
+  __bpf_md_ptr(void *, data);
+  __bpf_md_ptr(void *, data_end);
 
   __u32 family;
   __u32 remote_ip4; /* Stored in network byte order */
@@ -2444,6 +3262,7 @@ struct sk_msg_md {
   __u32 local_ip6[4]; /* Stored in network byte order */
   __u32 remote_port;  /* Stored in network byte order */
   __u32 local_port; /* stored in host byte order */
+  __u32 size;   /* Total size of sk_msg */
 };
 
 struct sk_reuseport_md {
@@ -2451,8 +3270,9 @@ struct sk_reuseport_md {
    * Start of directly accessible data. It begins from
    * the tcp/udp header.
    */
-  void *data;
-  void *data_end;   /* End of directly accessible data */
+  __bpf_md_ptr(void *, data);
+  /* End of directly accessible data */
+  __bpf_md_ptr(void *, data_end);
   /*
    * Total length of packet (starting from the tcp/udp header).
    * Note that the directly accessible bytes (data_end - data)
@@ -2487,12 +3307,27 @@ struct bpf_prog_info {
   char name[BPF_OBJ_NAME_LEN];
   __u32 ifindex;
   __u32 gpl_compatible:1;
+  __u32 :31; /* alignment pad */
   __u64 netns_dev;
   __u64 netns_ino;
   __u32 nr_jited_ksyms;
   __u32 nr_jited_func_lens;
   __aligned_u64 jited_ksyms;
   __aligned_u64 jited_func_lens;
+  __u32 btf_id;
+  __u32 func_info_rec_size;
+  __aligned_u64 func_info;
+  __u32 nr_func_info;
+  __u32 nr_line_info;
+  __aligned_u64 line_info;
+  __aligned_u64 jited_line_info;
+  __u32 nr_jited_line_info;
+  __u32 line_info_rec_size;
+  __u32 jited_line_info_rec_size;
+  __u32 nr_prog_tags;
+  __aligned_u64 prog_tags;
+  __u64 run_time_ns;
+  __u64 run_cnt;
 } __attribute__((aligned(8)));
 
 struct bpf_map_info {
@@ -2527,7 +3362,7 @@ struct bpf_sock_addr {
   __u32 user_ip4;   /* Allows 1,2,4-byte read and 4-byte write.
          * Stored in network byte order.
          */
-  __u32 user_ip6[4];  /* Allows 1,2,4-byte read an 4-byte write.
+  __u32 user_ip6[4];  /* Allows 1,2,4,8-byte read and 4,8-byte write.
          * Stored in network byte order.
          */
   __u32 user_port;  /* Allows 4-byte read and write.
@@ -2536,12 +3371,13 @@ struct bpf_sock_addr {
   __u32 family;   /* Allows 4-byte read, but no write */
   __u32 type;   /* Allows 4-byte read, but no write */
   __u32 protocol;   /* Allows 4-byte read, but no write */
-  __u32 msg_src_ip4;  /* Allows 1,2,4-byte read an 4-byte write.
+  __u32 msg_src_ip4;  /* Allows 1,2,4-byte read and 4-byte write.
          * Stored in network byte order.
          */
-  __u32 msg_src_ip6[4]; /* Allows 1,2,4-byte read an 4-byte write.
+  __u32 msg_src_ip6[4]; /* Allows 1,2,4,8-byte read and 4,8-byte write.
          * Stored in network byte order.
          */
+  __bpf_md_ptr(struct bpf_sock *, sk);
 };
 
 /* User bpf_sock_ops struct to access socket values and specify request ops
@@ -2593,13 +3429,15 @@ struct bpf_sock_ops {
   __u32 sk_txhash;
   __u64 bytes_received;
   __u64 bytes_acked;
+  __bpf_md_ptr(struct bpf_sock *, sk);
 };
 
 /* Definitions for bpf_sock_ops_cb_flags */
 #define BPF_SOCK_OPS_RTO_CB_FLAG  (1<<0)
 #define BPF_SOCK_OPS_RETRANS_CB_FLAG  (1<<1)
 #define BPF_SOCK_OPS_STATE_CB_FLAG  (1<<2)
-#define BPF_SOCK_OPS_ALL_CB_FLAGS       0x7   /* Mask of all currently
+#define BPF_SOCK_OPS_RTT_CB_FLAG  (1<<3)
+#define BPF_SOCK_OPS_ALL_CB_FLAGS       0xF   /* Mask of all currently
                * supported cb flags
                */
 
@@ -2654,6 +3492,8 @@ enum {
   BPF_SOCK_OPS_TCP_LISTEN_CB, /* Called on listen(2), right after
            * socket transition to LISTEN state.
            */
+  BPF_SOCK_OPS_RTT_CB,    /* Called on every RTT.
+           */
 };
 
 /* List of TCP states. There is a build check in net/ipv4/tcp.c to detect
@@ -2701,11 +3541,15 @@ struct bpf_cgroup_dev_ctx {
   __u32 minor;
 };
 
+struct bpf_raw_tracepoint_args {
+  __u64 args[0];
+};
+
 /* DIRECT:  Skip the FIB rules and go to FIB table associated with device
  * OUTPUT:  Do lookup from egress perspective; default is ingress
  */
-#define BPF_FIB_LOOKUP_DIRECT  BIT(0)
-#define BPF_FIB_LOOKUP_OUTPUT  BIT(1)
+#define BPF_FIB_LOOKUP_DIRECT  (1U << 0)
+#define BPF_FIB_LOOKUP_OUTPUT  (1U << 1)
 
 enum {
   BPF_FIB_LKUP_RET_SUCCESS,      /* lookup successful */
@@ -2777,6 +3621,10 @@ enum bpf_task_fd_type {
   BPF_FD_TYPE_URETPROBE,    /* filename + offset */
 };
 
+#define BPF_FLOW_DISSECTOR_F_PARSE_1ST_FRAG   (1U << 0)
+#define BPF_FLOW_DISSECTOR_F_STOP_AT_FLOW_LABEL   (1U << 1)
+#define BPF_FLOW_DISSECTOR_F_STOP_AT_ENCAP    (1U << 2)
+
 struct bpf_flow_keys {
   __u16 nhoff;
   __u16 thoff;
@@ -2798,6 +3646,47 @@ struct bpf_flow_keys {
       __u32 ipv6_dst[4];  /* in6_addr; network order */
     };
   };
+  __u32 flags;
+  __be32  flow_label;
+};
+
+struct bpf_func_info {
+  __u32 insn_off;
+  __u32 type_id;
+};
+
+#define BPF_LINE_INFO_LINE_NUM(line_col)  ((line_col) >> 10)
+#define BPF_LINE_INFO_LINE_COL(line_col)  ((line_col) & 0x3ff)
+
+struct bpf_line_info {
+  __u32 insn_off;
+  __u32 file_name_off;
+  __u32 line_off;
+  __u32 line_col;
+};
+
+struct bpf_spin_lock {
+  __u32 val;
+};
+
+struct bpf_sysctl {
+  __u32 write;    /* Sysctl is being read (= 0) or written (= 1).
+         * Allows 1,2,4-byte read, but no write.
+         */
+  __u32 file_pos; /* Sysctl file position to read from, write to.
+         * Allows 1,2,4-byte read an 4-byte write.
+         */
+};
+
+struct bpf_sockopt {
+  __bpf_md_ptr(struct bpf_sock *, sk);
+  __bpf_md_ptr(void *, optval);
+  __bpf_md_ptr(void *, optval_end);
+
+  __s32 level;
+  __s32 optname;
+  __s32 optlen;
+  __s32 retval;
 };
 
 #endif /* _UAPI__LINUX_BPF_H__ */

--- a/katran/lib/linux_includes/bpf_helpers.h
+++ b/katran/lib/linux_includes/bpf_helpers.h
@@ -7,6 +7,17 @@
  */
 #define SEC(NAME) __attribute__((section(NAME), used))
 
+#define __uint(name, val) int (*name)[val]
+#define __type(name, val) val *name
+
+/* helper macro to print out debug messages */
+#define bpf_printk(fmt, ...)        \
+({              \
+  char ____fmt[] = fmt;       \
+  bpf_trace_printk(____fmt, sizeof(____fmt),  \
+       ##__VA_ARGS__);    \
+})
+
 /* helper functions called from eBPF programs written in C */
 static void *(*bpf_map_lookup_elem)(void *map, void *key) =
   (void *) BPF_FUNC_map_lookup_elem;
@@ -15,7 +26,14 @@ static int (*bpf_map_update_elem)(void *map, void *key, void *value,
   (void *) BPF_FUNC_map_update_elem;
 static int (*bpf_map_delete_elem)(void *map, void *key) =
   (void *) BPF_FUNC_map_delete_elem;
-static int (*bpf_probe_read)(void *dst, int size, void *unsafe_ptr) =
+static int (*bpf_map_push_elem)(void *map, void *value,
+        unsigned long long flags) =
+  (void *) BPF_FUNC_map_push_elem;
+static int (*bpf_map_pop_elem)(void *map, void *value) =
+  (void *) BPF_FUNC_map_pop_elem;
+static int (*bpf_map_peek_elem)(void *map, void *value) =
+  (void *) BPF_FUNC_map_peek_elem;
+static int (*bpf_probe_read)(void *dst, int size, const void *unsafe_ptr) =
   (void *) BPF_FUNC_probe_read;
 static unsigned long long (*bpf_ktime_get_ns)(void) =
   (void *) BPF_FUNC_ktime_get_ns;
@@ -46,7 +64,7 @@ static int (*bpf_perf_event_output)(void *ctx, void *map,
   (void *) BPF_FUNC_perf_event_output;
 static int (*bpf_get_stackid)(void *ctx, void *map, int flags) =
   (void *) BPF_FUNC_get_stackid;
-static int (*bpf_probe_write_user)(void *dst, void *src, int size) =
+static int (*bpf_probe_write_user)(void *dst, const void *src, int size) =
   (void *) BPF_FUNC_probe_write_user;
 static int (*bpf_current_task_under_cgroup)(void *map, int index) =
   (void *) BPF_FUNC_current_task_under_cgroup;
@@ -64,19 +82,26 @@ static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
   (void *) BPF_FUNC_xdp_adjust_head;
 static int (*bpf_xdp_adjust_meta)(void *ctx, int offset) =
   (void *) BPF_FUNC_xdp_adjust_meta;
+static int (*bpf_get_socket_cookie)(void *ctx) =
+  (void *) BPF_FUNC_get_socket_cookie;
 static int (*bpf_setsockopt)(void *ctx, int level, int optname, void *optval,
            int optlen) =
   (void *) BPF_FUNC_setsockopt;
-static int (*bpf_sk_redirect_map)(void *map, int key, int flags) =
-  (void *) BPF_FUNC_sk_redirect_map;
 static int (*bpf_getsockopt)(void *ctx, int level, int optname, void *optval,
-                             int optlen) =
+           int optlen) =
   (void *) BPF_FUNC_getsockopt;
 static int (*bpf_sock_ops_cb_flags_set)(void *ctx, int flags) =
   (void *) BPF_FUNC_sock_ops_cb_flags_set;
+static int (*bpf_sk_redirect_map)(void *ctx, void *map, int key, int flags) =
+  (void *) BPF_FUNC_sk_redirect_map;
+static int (*bpf_sk_redirect_hash)(void *ctx, void *map, void *key, int flags) =
+  (void *) BPF_FUNC_sk_redirect_hash;
 static int (*bpf_sock_map_update)(void *map, void *key, void *value,
           unsigned long long flags) =
   (void *) BPF_FUNC_sock_map_update;
+static int (*bpf_sock_hash_update)(void *map, void *key, void *value,
+           unsigned long long flags) =
+  (void *) BPF_FUNC_sock_hash_update;
 static int (*bpf_perf_event_read_value)(void *map, unsigned long long flags,
           void *buf, unsigned int buf_size) =
   (void *) BPF_FUNC_perf_event_read_value;
@@ -85,12 +110,27 @@ static int (*bpf_perf_prog_read_value)(void *ctx, void *buf,
   (void *) BPF_FUNC_perf_prog_read_value;
 static int (*bpf_override_return)(void *ctx, unsigned long rc) =
   (void *) BPF_FUNC_override_return;
+static int (*bpf_msg_redirect_map)(void *ctx, void *map, int key, int flags) =
+  (void *) BPF_FUNC_msg_redirect_map;
+static int (*bpf_msg_redirect_hash)(void *ctx,
+            void *map, void *key, int flags) =
+  (void *) BPF_FUNC_msg_redirect_hash;
+static int (*bpf_msg_apply_bytes)(void *ctx, int len) =
+  (void *) BPF_FUNC_msg_apply_bytes;
+static int (*bpf_msg_cork_bytes)(void *ctx, int len) =
+  (void *) BPF_FUNC_msg_cork_bytes;
+static int (*bpf_msg_pull_data)(void *ctx, int start, int end, int flags) =
+  (void *) BPF_FUNC_msg_pull_data;
+static int (*bpf_msg_push_data)(void *ctx, int start, int end, int flags) =
+  (void *) BPF_FUNC_msg_push_data;
+static int (*bpf_msg_pop_data)(void *ctx, int start, int cut, int flags) =
+  (void *) BPF_FUNC_msg_pop_data;
 static int (*bpf_bind)(void *ctx, void *addr, int addr_len) =
   (void *) BPF_FUNC_bind;
 static int (*bpf_xdp_adjust_tail)(void *ctx, int offset) =
   (void *) BPF_FUNC_xdp_adjust_tail;
 static int (*bpf_skb_get_xfrm_state)(void *ctx, int index, void *state,
-                                     int size, int flags) =
+             int size, int flags) =
   (void *) BPF_FUNC_skb_get_xfrm_state;
 static int (*bpf_sk_select_reuseport)(void *ctx, void *map, void *key, __u32 flags) =
   (void *) BPF_FUNC_sk_select_reuseport;
@@ -124,6 +164,70 @@ static unsigned long long (*bpf_skb_cgroup_id)(void *ctx) =
   (void *) BPF_FUNC_skb_cgroup_id;
 static unsigned long long (*bpf_skb_ancestor_cgroup_id)(void *ctx, int level) =
   (void *) BPF_FUNC_skb_ancestor_cgroup_id;
+static struct bpf_sock *(*bpf_sk_lookup_tcp)(void *ctx,
+               struct bpf_sock_tuple *tuple,
+               int size, unsigned long long netns_id,
+               unsigned long long flags) =
+  (void *) BPF_FUNC_sk_lookup_tcp;
+static struct bpf_sock *(*bpf_skc_lookup_tcp)(void *ctx,
+               struct bpf_sock_tuple *tuple,
+               int size, unsigned long long netns_id,
+               unsigned long long flags) =
+  (void *) BPF_FUNC_skc_lookup_tcp;
+static struct bpf_sock *(*bpf_sk_lookup_udp)(void *ctx,
+               struct bpf_sock_tuple *tuple,
+               int size, unsigned long long netns_id,
+               unsigned long long flags) =
+  (void *) BPF_FUNC_sk_lookup_udp;
+static int (*bpf_sk_release)(struct bpf_sock *sk) =
+  (void *) BPF_FUNC_sk_release;
+static int (*bpf_skb_vlan_push)(void *ctx, __be16 vlan_proto, __u16 vlan_tci) =
+  (void *) BPF_FUNC_skb_vlan_push;
+static int (*bpf_skb_vlan_pop)(void *ctx) =
+  (void *) BPF_FUNC_skb_vlan_pop;
+static int (*bpf_rc_pointer_rel)(void *ctx, int rel_x, int rel_y) =
+  (void *) BPF_FUNC_rc_pointer_rel;
+static void (*bpf_spin_lock)(struct bpf_spin_lock *lock) =
+  (void *) BPF_FUNC_spin_lock;
+static void (*bpf_spin_unlock)(struct bpf_spin_lock *lock) =
+  (void *) BPF_FUNC_spin_unlock;
+static struct bpf_sock *(*bpf_sk_fullsock)(struct bpf_sock *sk) =
+  (void *) BPF_FUNC_sk_fullsock;
+static struct bpf_tcp_sock *(*bpf_tcp_sock)(struct bpf_sock *sk) =
+  (void *) BPF_FUNC_tcp_sock;
+static struct bpf_sock *(*bpf_get_listener_sock)(struct bpf_sock *sk) =
+  (void *) BPF_FUNC_get_listener_sock;
+static int (*bpf_skb_ecn_set_ce)(void *ctx) =
+  (void *) BPF_FUNC_skb_ecn_set_ce;
+static int (*bpf_tcp_check_syncookie)(struct bpf_sock *sk,
+      void *ip, int ip_len, void *tcp, int tcp_len) =
+  (void *) BPF_FUNC_tcp_check_syncookie;
+static int (*bpf_sysctl_get_name)(void *ctx, char *buf,
+          unsigned long long buf_len,
+          unsigned long long flags) =
+  (void *) BPF_FUNC_sysctl_get_name;
+static int (*bpf_sysctl_get_current_value)(void *ctx, char *buf,
+             unsigned long long buf_len) =
+  (void *) BPF_FUNC_sysctl_get_current_value;
+static int (*bpf_sysctl_get_new_value)(void *ctx, char *buf,
+               unsigned long long buf_len) =
+  (void *) BPF_FUNC_sysctl_get_new_value;
+static int (*bpf_sysctl_set_new_value)(void *ctx, const char *buf,
+               unsigned long long buf_len) =
+  (void *) BPF_FUNC_sysctl_set_new_value;
+static int (*bpf_strtol)(const char *buf, unsigned long long buf_len,
+       unsigned long long flags, long *res) =
+  (void *) BPF_FUNC_strtol;
+static int (*bpf_strtoul)(const char *buf, unsigned long long buf_len,
+        unsigned long long flags, unsigned long *res) =
+  (void *) BPF_FUNC_strtoul;
+static void *(*bpf_sk_storage_get)(void *map, struct bpf_sock *sk,
+           void *value, __u64 flags) =
+  (void *) BPF_FUNC_sk_storage_get;
+static int (*bpf_sk_storage_delete)(void *map, struct bpf_sock *sk) =
+  (void *)BPF_FUNC_sk_storage_delete;
+static int (*bpf_send_signal)(unsigned sig) = (void *)BPF_FUNC_send_signal;
+
 /* llvm builtin functions that eBPF C program may use to
  * emit BPF_LD_ABS and BPF_LD_IND instructions
  */
@@ -144,6 +248,8 @@ struct bpf_map_def {
   unsigned int value_size;
   unsigned int max_entries;
   unsigned int map_flags;
+  unsigned int inner_map_idx;
+  unsigned int numa_node;
 };
 
 #define BPF_ANNOTATE_KV_PAIR(name, type_key, type_val)    \
@@ -157,6 +263,8 @@ struct bpf_map_def {
 
 static int (*bpf_skb_load_bytes)(void *ctx, int off, void *to, int len) =
   (void *) BPF_FUNC_skb_load_bytes;
+static int (*bpf_skb_load_bytes_relative)(void *ctx, int off, void *to, int len, __u32 start_header) =
+  (void *) BPF_FUNC_skb_load_bytes_relative;
 static int (*bpf_skb_store_bytes)(void *ctx, int off, void *from, int len, int flags) =
   (void *) BPF_FUNC_skb_store_bytes;
 static int (*bpf_l3_csum_replace)(void *ctx, int off, int from, int to, int flags) =
@@ -169,13 +277,48 @@ static int (*bpf_skb_under_cgroup)(void *ctx, void *map, int index) =
   (void *) BPF_FUNC_skb_under_cgroup;
 static int (*bpf_skb_change_head)(void *, int len, int flags) =
   (void *) BPF_FUNC_skb_change_head;
+static int (*bpf_skb_pull_data)(void *, int len) =
+  (void *) BPF_FUNC_skb_pull_data;
+static unsigned int (*bpf_get_cgroup_classid)(void *ctx) =
+  (void *) BPF_FUNC_get_cgroup_classid;
+static unsigned int (*bpf_get_route_realm)(void *ctx) =
+  (void *) BPF_FUNC_get_route_realm;
+static int (*bpf_skb_change_proto)(void *ctx, __be16 proto, __u64 flags) =
+  (void *) BPF_FUNC_skb_change_proto;
+static int (*bpf_skb_change_type)(void *ctx, __u32 type) =
+  (void *) BPF_FUNC_skb_change_type;
+static unsigned int (*bpf_get_hash_recalc)(void *ctx) =
+  (void *) BPF_FUNC_get_hash_recalc;
+static unsigned long long (*bpf_get_current_task)(void) =
+  (void *) BPF_FUNC_get_current_task;
+static int (*bpf_skb_change_tail)(void *ctx, __u32 len, __u64 flags) =
+  (void *) BPF_FUNC_skb_change_tail;
+static long long (*bpf_csum_update)(void *ctx, __u32 csum) =
+  (void *) BPF_FUNC_csum_update;
+static void (*bpf_set_hash_invalid)(void *ctx) =
+  (void *) BPF_FUNC_set_hash_invalid;
+static int (*bpf_get_numa_node_id)(void) =
+  (void *) BPF_FUNC_get_numa_node_id;
+static int (*bpf_probe_read_str)(void *ctx, __u32 size,
+         const void *unsafe_ptr) =
+  (void *) BPF_FUNC_probe_read_str;
+static unsigned int (*bpf_get_socket_uid)(void *ctx) =
+  (void *) BPF_FUNC_get_socket_uid;
+static unsigned int (*bpf_set_hash)(void *ctx, __u32 hash) =
+  (void *) BPF_FUNC_set_hash;
+static int (*bpf_skb_adjust_room)(void *ctx, __s32 len_diff, __u32 mode,
+          unsigned long long flags) =
+  (void *) BPF_FUNC_skb_adjust_room;
 
 /* Scan the ARCH passed in from ARCH env variable (see Makefile) */
 #if defined(__TARGET_ARCH_x86)
   #define bpf_target_x86
   #define bpf_target_defined
-#elif defined(__TARGET_ARCH_s930x)
-  #define bpf_target_s930x
+#elif defined(__TARGET_ARCH_s390)
+  #define bpf_target_s390
+  #define bpf_target_defined
+#elif defined(__TARGET_ARCH_arm)
+  #define bpf_target_arm
   #define bpf_target_defined
 #elif defined(__TARGET_ARCH_arm64)
   #define bpf_target_arm64
@@ -197,8 +340,10 @@ static int (*bpf_skb_change_head)(void *, int len, int flags) =
 #ifndef bpf_target_defined
 #if defined(__x86_64__)
   #define bpf_target_x86
-#elif defined(__s390x__)
-  #define bpf_target_s930x
+#elif defined(__s390__)
+  #define bpf_target_s390
+#elif defined(__arm__)
+  #define bpf_target_arm
 #elif defined(__aarch64__)
   #define bpf_target_arm64
 #elif defined(__mips__)
@@ -212,6 +357,7 @@ static int (*bpf_skb_change_head)(void *, int len, int flags) =
 
 #if defined(bpf_target_x86)
 
+#ifdef __KERNEL__
 #define PT_REGS_PARM1(x) ((x)->di)
 #define PT_REGS_PARM2(x) ((x)->si)
 #define PT_REGS_PARM3(x) ((x)->dx)
@@ -222,32 +368,79 @@ static int (*bpf_skb_change_head)(void *, int len, int flags) =
 #define PT_REGS_RC(x) ((x)->ax)
 #define PT_REGS_SP(x) ((x)->sp)
 #define PT_REGS_IP(x) ((x)->ip)
+#else
+#ifdef __i386__
+/* i386 kernel is built with -mregparm=3 */
+#define PT_REGS_PARM1(x) ((x)->eax)
+#define PT_REGS_PARM2(x) ((x)->edx)
+#define PT_REGS_PARM3(x) ((x)->ecx)
+#define PT_REGS_PARM4(x) 0
+#define PT_REGS_PARM5(x) 0
+#define PT_REGS_RET(x) ((x)->esp)
+#define PT_REGS_FP(x) ((x)->ebp)
+#define PT_REGS_RC(x) ((x)->eax)
+#define PT_REGS_SP(x) ((x)->esp)
+#define PT_REGS_IP(x) ((x)->eip)
+#else
+#define PT_REGS_PARM1(x) ((x)->rdi)
+#define PT_REGS_PARM2(x) ((x)->rsi)
+#define PT_REGS_PARM3(x) ((x)->rdx)
+#define PT_REGS_PARM4(x) ((x)->rcx)
+#define PT_REGS_PARM5(x) ((x)->r8)
+#define PT_REGS_RET(x) ((x)->rsp)
+#define PT_REGS_FP(x) ((x)->rbp)
+#define PT_REGS_RC(x) ((x)->rax)
+#define PT_REGS_SP(x) ((x)->rsp)
+#define PT_REGS_IP(x) ((x)->rip)
+#endif
+#endif
 
-#elif defined(bpf_target_s390x)
+#elif defined(bpf_target_s390)
 
-#define PT_REGS_PARM1(x) ((x)->gprs[2])
-#define PT_REGS_PARM2(x) ((x)->gprs[3])
-#define PT_REGS_PARM3(x) ((x)->gprs[4])
-#define PT_REGS_PARM4(x) ((x)->gprs[5])
-#define PT_REGS_PARM5(x) ((x)->gprs[6])
-#define PT_REGS_RET(x) ((x)->gprs[14])
-#define PT_REGS_FP(x) ((x)->gprs[11]) /* Works only with CONFIG_FRAME_POINTER */
-#define PT_REGS_RC(x) ((x)->gprs[2])
-#define PT_REGS_SP(x) ((x)->gprs[15])
-#define PT_REGS_IP(x) ((x)->psw.addr)
+/* s390 provides user_pt_regs instead of struct pt_regs to userspace */
+struct pt_regs;
+#define PT_REGS_S390 const volatile user_pt_regs
+#define PT_REGS_PARM1(x) (((PT_REGS_S390 *)(x))->gprs[2])
+#define PT_REGS_PARM2(x) (((PT_REGS_S390 *)(x))->gprs[3])
+#define PT_REGS_PARM3(x) (((PT_REGS_S390 *)(x))->gprs[4])
+#define PT_REGS_PARM4(x) (((PT_REGS_S390 *)(x))->gprs[5])
+#define PT_REGS_PARM5(x) (((PT_REGS_S390 *)(x))->gprs[6])
+#define PT_REGS_RET(x) (((PT_REGS_S390 *)(x))->gprs[14])
+/* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_FP(x) (((PT_REGS_S390 *)(x))->gprs[11])
+#define PT_REGS_RC(x) (((PT_REGS_S390 *)(x))->gprs[2])
+#define PT_REGS_SP(x) (((PT_REGS_S390 *)(x))->gprs[15])
+#define PT_REGS_IP(x) (((PT_REGS_S390 *)(x))->psw.addr)
+
+#elif defined(bpf_target_arm)
+
+#define PT_REGS_PARM1(x) ((x)->uregs[0])
+#define PT_REGS_PARM2(x) ((x)->uregs[1])
+#define PT_REGS_PARM3(x) ((x)->uregs[2])
+#define PT_REGS_PARM4(x) ((x)->uregs[3])
+#define PT_REGS_PARM5(x) ((x)->uregs[4])
+#define PT_REGS_RET(x) ((x)->uregs[14])
+#define PT_REGS_FP(x) ((x)->uregs[11]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->uregs[0])
+#define PT_REGS_SP(x) ((x)->uregs[13])
+#define PT_REGS_IP(x) ((x)->uregs[12])
 
 #elif defined(bpf_target_arm64)
 
-#define PT_REGS_PARM1(x) ((x)->regs[0])
-#define PT_REGS_PARM2(x) ((x)->regs[1])
-#define PT_REGS_PARM3(x) ((x)->regs[2])
-#define PT_REGS_PARM4(x) ((x)->regs[3])
-#define PT_REGS_PARM5(x) ((x)->regs[4])
-#define PT_REGS_RET(x) ((x)->regs[30])
-#define PT_REGS_FP(x) ((x)->regs[29]) /* Works only with CONFIG_FRAME_POINTER */
-#define PT_REGS_RC(x) ((x)->regs[0])
-#define PT_REGS_SP(x) ((x)->sp)
-#define PT_REGS_IP(x) ((x)->pc)
+/* arm64 provides struct user_pt_regs instead of struct pt_regs to userspace */
+struct pt_regs;
+#define PT_REGS_ARM64 const volatile struct user_pt_regs
+#define PT_REGS_PARM1(x) (((PT_REGS_ARM64 *)(x))->regs[0])
+#define PT_REGS_PARM2(x) (((PT_REGS_ARM64 *)(x))->regs[1])
+#define PT_REGS_PARM3(x) (((PT_REGS_ARM64 *)(x))->regs[2])
+#define PT_REGS_PARM4(x) (((PT_REGS_ARM64 *)(x))->regs[3])
+#define PT_REGS_PARM5(x) (((PT_REGS_ARM64 *)(x))->regs[4])
+#define PT_REGS_RET(x) (((PT_REGS_ARM64 *)(x))->regs[30])
+/* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_FP(x) (((PT_REGS_ARM64 *)(x))->regs[29])
+#define PT_REGS_RC(x) (((PT_REGS_ARM64 *)(x))->regs[0])
+#define PT_REGS_SP(x) (((PT_REGS_ARM64 *)(x))->sp)
+#define PT_REGS_IP(x) (((PT_REGS_ARM64 *)(x))->pc)
 
 #elif defined(bpf_target_mips)
 
@@ -293,10 +486,10 @@ static int (*bpf_skb_change_head)(void *, int len, int flags) =
 
 #endif
 
-#ifdef bpf_target_powerpc
+#if defined(bpf_target_powerpc)
 #define BPF_KPROBE_READ_RET_IP(ip, ctx)   ({ (ip) = (ctx)->link; })
 #define BPF_KRETPROBE_READ_RET_IP   BPF_KPROBE_READ_RET_IP
-#elif bpf_target_sparc
+#elif defined(bpf_target_sparc)
 #define BPF_KPROBE_READ_RET_IP(ip, ctx)   ({ (ip) = PT_REGS_RET(ctx); })
 #define BPF_KRETPROBE_READ_RET_IP   BPF_KPROBE_READ_RET_IP
 #else


### PR DESCRIPTION
subj. current version is from around 4.18 or so.  there were plenty of helpers/constants were added. to be able to use em in C bpf program - we need to sync this two files from upstream (5.3 were used). this is backward compatible (aka old programs, which were working on old kernels - still would be compiled and works).