### PR TITLE
[katran]: rework ipip healthchecks

### DIFF
--- a/katran/decap/testing/CMakeLists.txt
+++ b/katran/decap/testing/CMakeLists.txt
@@ -6,6 +6,6 @@ add_executable(xdpdecap_tester
 target_link_libraries(xdpdecap_tester
     "${GFLAGS}"
     "${PTHREAD}"
-    xdptester
+    bpftester
     decap
 )

--- a/katran/decap/testing/xdpdecap_tester.cpp
+++ b/katran/decap/testing/xdpdecap_tester.cpp
@@ -24,7 +24,7 @@
 #include "katran/decap/testing/XdpDecapTestFixtures.h"
 #include "katran/decap/XdpDecap.h"
 #include "katran/decap/XdpDecapStructs.h"
-#include "katran/lib/testing/XdpTester.h"
+#include "katran/lib/testing/BpfTester.h"
 
 DEFINE_string(pcap_input, "", "path to input pcap file");
 DEFINE_string(pcap_output, "", "path to output pcap file");
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
   config.outputFileName = FLAGS_pcap_output;
   config.inputData = katran::testing::inputTestFixtures;
   config.outputData = katran::testing::outputTestFixtures;
-  katran::XdpTester tester(config);
+  katran::BpfTester tester(config);
   if (FLAGS_print_base64) {
     if (FLAGS_pcap_input.empty()) {
       std::cout << "pcap_input is not specified! exiting";

--- a/katran/lib/BalancerStructs.h
+++ b/katran/lib/BalancerStructs.h
@@ -30,6 +30,11 @@ struct ctl_value {
   };
 };
 
+// mac address for healthchecking
+struct hc_mac {
+  uint8_t mac[6];
+};
+
 // vip's definition for lookup
 struct vip_definition {
   union {

--- a/katran/lib/BpfAdapter.cpp
+++ b/katran/lib/BpfAdapter.cpp
@@ -427,9 +427,34 @@ int BpfAdapter::testXdpProg(
     void* data_out,
     uint32_t* size_out,
     uint32_t* retval,
-    uint32_t* duration) {
-  return bpf_prog_test_run(
-      prog_fd, repeat, data, data_size, data_out, size_out, retval, duration);
+    uint32_t* duration,
+    void* ctx_in,
+    uint32_t ctx_size_in,
+    void* ctx_out,
+    uint32_t* ctx_size_out) {
+  struct bpf_prog_test_run_attr attr = {};
+  attr.prog_fd = prog_fd;
+  attr.repeat = repeat;
+  attr.data_in = data;
+  attr.data_size_in = data_size;
+  attr.data_out = data_out;
+  attr.ctx_in = ctx_in;
+  attr.ctx_size_in = ctx_size_in;
+  attr.ctx_out = ctx_out;
+  auto ret = bpf_prog_test_run_xattr(&attr);
+  if (size_out) {
+    *size_out = attr.data_size_out;
+  }
+  if (retval) {
+    *retval = attr.retval;
+  }
+  if (duration) {
+    *duration = attr.duration;
+  }
+  if (ctx_size_out) {
+    *ctx_size_out = attr.ctx_size_out;
+  }
+  return ret;
 }
 
 int BpfAdapter::modifyXdpProg(

--- a/katran/lib/BpfAdapter.h
+++ b/katran/lib/BpfAdapter.h
@@ -407,6 +407,10 @@ class BpfAdapter {
    * @param uint32_t* size_out size of the output packet. optional
    * @param uint32_t* retval return value of the program
    * @param uint32_t* duration how long did it take to run a test
+   * @param void* ctx_in optional pointer to context
+   * @param uint32_t ctx_size_in size of the context
+   * @param void* ctx_out optional pointer to output context
+   * @param uint32_t* ctx_size_out pointer to the size of ctx after test run
    * @return int result of the test. 0 on success, non 0 otherwise
    *
    * helper function which allow user to test xdp program by specifying
@@ -422,7 +426,11 @@ class BpfAdapter {
       void* data_out,
       uint32_t* size_out = nullptr,
       uint32_t* retval = nullptr,
-      uint32_t* duration = nullptr);
+      uint32_t* duration = nullptr,
+      void* ctx_in = nullptr,
+      uint32_t ctx_size_in = 0,
+      void* ctx_out = nullptr,
+      uint32_t* ctx_size_out = nullptr);
 
   /**
    * @param int prog_fd descriptor of the program

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -75,7 +75,7 @@ enum class KatranMonitorState {
   ENABLED,
 };
 
-}
+} // namespace
 
 /**
  * This class implements all routines to interact with katran load balancer
@@ -646,10 +646,17 @@ class KatranLb {
    */
   void setupGueEnvironment();
 
+  /*
+   * setupHcEnvironment prepare katran to run healthchecks (e.g. setting up
+   * src addresses for outer packets)
+   */
+  void setupHcEnvironment();
+
   /**
-   * enableRecirculation enables katran to use recirculation technics, where some codepaths
-   * inside xdp forwarding plane, after packets monipulation, rerun whole load balancer's code
-   * (e.g. after decapsulation). it is acheaving this by register itself in internal programs array
+   * enableRecirculation enables katran to use recirculation technics, where
+   * some codepaths inside xdp forwarding plane, after packets monipulation,
+   * rerun whole load balancer's code (e.g. after decapsulation). it is
+   * acheaving this by register itself in internal programs array
    */
   void enableRecirculation();
 

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -146,6 +146,7 @@ struct KatranMonitorConfig {
  * @param memlockUnlimited should katran set memlock to unlimited by default
  * @param katranSrcV4 string ipv4 source address for GUE packets
  * @param katranSrcV6 string ipv6 source address for GUE packets
+ * @param std::vector<uint8_t> localMac mac address of local server
  *
  * note about rootMapPath and rootMapPos:
  * katran has two modes of operation.
@@ -191,6 +192,7 @@ struct KatranConfig {
   bool memlockUnlimited = true;
   std::string katranSrcV4 = kAddressNotSpecified;
   std::string katranSrcV6 = kAddressNotSpecified;
+  std::vector<uint8_t> localMac;
 };
 
 /**
@@ -244,12 +246,16 @@ struct HealthCheckProgStats {
  * been enabled/compiled in bpf forwarding plane
  * @param introspection flag which indicates that katran introspection is
  * enabled
+ * @param gueEncap flag which indicates that GUE instead of IPIP should be used
+ * @param directHealthchecking flag which inidcates that hc encapsulation would
+ * be directly created instead of using tunnel interfaces
  */
 struct KatranFeatures {
   bool srcRouting{false};
   bool inlineDecap{false};
   bool introspection{false};
   bool gueEncap{false};
+  bool directHealthchecking{false};
 };
 
 /**

--- a/katran/lib/Makefile-bpf
+++ b/katran/lib/Makefile-bpf
@@ -8,13 +8,13 @@ PFLAGS = $(DEBUGFLAGS)
 
 INCLUDEFLAGS = -I$(obj)/usr/include \
 	       -I$(obj)/include \
-	       #-I$(obj)/bpfprog/include \
 
 
 
 always = bpf/balancer_kern.o
 always += bpf/adapter_integration_test_kern.o
 always += bpf/healthchecking_ipip.o
+always += bpf/healthchecking_kern.o
 always += bpf/xdp_pktcntr.o
 always += bpf/xdp_root.o
 

--- a/katran/lib/bpf/balancer_maps.h
+++ b/katran/lib/bpf/balancer_maps.h
@@ -46,7 +46,6 @@ struct bpf_map_def SEC("maps") lru_maps_mapping = {
   .max_entries = MAX_SUPPORTED_CPUS,
   .map_flags = NO_FLAGS,
 };
-BPF_ANNOTATE_KV_PAIR(lru_maps_mapping, __u32, __u32);
 
 // fallback lru. we should never hit this one outside of unittests
 struct bpf_map_def SEC("maps") fallback_lru_cache = {

--- a/katran/lib/bpf/csum_helpers.h
+++ b/katran/lib/bpf/csum_helpers.h
@@ -1,0 +1,88 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __CSUM_HELPERS_H
+#define __CSUM_HELPERS_H
+
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+
+#include "bpf.h"
+#include "bpf_helpers.h"
+
+__attribute__((__always_inline__))
+static inline __u16 csum_fold_helper(__u64 csum) {
+  int i;
+#pragma unroll
+  for (i = 0; i < 4; i ++) {
+    if (csum >> 16)
+      csum = (csum & 0xffff) + (csum >> 16);
+  }
+  return ~csum;
+}
+
+__attribute__((__always_inline__))
+static int min_helper(int a, int b) {
+  return a < b ? a : b;
+}
+
+__attribute__((__always_inline__))
+static inline void ipv4_csum(void *data_start, int data_size,  __u64 *csum) {
+  *csum = bpf_csum_diff(0, 0, data_start, data_size, *csum);
+  *csum = csum_fold_helper(*csum);
+}
+
+__attribute__((__always_inline__))
+static inline void ipv4_csum_inline(void *iph, __u64 *csum) {
+  __u16 *next_iph_u16 = (__u16 *)iph;
+  #pragma clang loop unroll(full)
+  for (int i = 0; i < sizeof(struct iphdr) >> 1; i++) {
+     *csum += *next_iph_u16++;
+  }
+  *csum = csum_fold_helper(*csum);
+}
+
+__attribute__((__always_inline__))
+static inline void ipv4_l4_csum(void *data_start, int data_size,
+                                __u64 *csum, struct iphdr *iph) {
+  __u32 tmp = 0;
+  *csum = bpf_csum_diff(0, 0, &iph->saddr, sizeof(__be32), *csum);
+  *csum = bpf_csum_diff(0, 0, &iph->daddr, sizeof(__be32), *csum);
+  tmp = __builtin_bswap32((__u32)(iph->protocol));
+  *csum = bpf_csum_diff(0, 0, &tmp, sizeof(__u32), *csum);
+  tmp = __builtin_bswap32((__u32)(data_size));
+  *csum = bpf_csum_diff(0, 0, &tmp, sizeof(__u32), *csum);
+  *csum = bpf_csum_diff(0, 0, data_start, data_size, *csum);
+  *csum = csum_fold_helper(*csum);
+}
+
+__attribute__((__always_inline__))
+static inline void ipv6_csum(void *data_start, int data_size,
+                             __u64 *csum, struct ipv6hdr *ip6h) {
+  // ipv6 pseudo header
+  __u32 tmp = 0;
+  *csum = bpf_csum_diff(0, 0, &ip6h->saddr, sizeof(struct in6_addr), *csum);
+  *csum = bpf_csum_diff(0, 0, &ip6h->daddr, sizeof(struct in6_addr), *csum);
+  tmp = __builtin_bswap32((__u32)(data_size));
+  *csum = bpf_csum_diff(0, 0, &tmp, sizeof(__u32), *csum);
+  tmp = __builtin_bswap32((__u32)(ip6h->nexthdr));
+  *csum = bpf_csum_diff(0, 0, &tmp, sizeof(__u32), *csum);
+  // sum over payload
+  *csum = bpf_csum_diff(0, 0, data_start, data_size, *csum);
+  *csum = csum_fold_helper(*csum);
+}
+
+#endif  // of __CSUM_HELPERS_H

--- a/katran/lib/bpf/encap_helpers.h
+++ b/katran/lib/bpf/encap_helpers.h
@@ -1,0 +1,87 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __ENCAP_HELPERS_H
+#define __ENCAP_HELPERS_H
+
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/udp.h>
+#include <string.h>
+
+#include "balancer_consts.h"
+#include "bpf.h"
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
+#include "csum_helpers.h"
+
+__attribute__((__always_inline__)) static inline void create_v4_hdr(
+    struct iphdr* iph,
+    __u8 tos,
+    __u32 saddr,
+    __u32 daddr,
+    __u16 pkt_bytes,
+    __u8 proto) {
+  __u64 csum = 0;
+  iph->version = 4;
+  iph->ihl = 5;
+  iph->frag_off = 0;
+  iph->protocol = proto;
+  iph->check = 0;
+#ifdef COPY_INNER_PACKET_TOS
+  iph->tos = tos;
+#else
+  iph->tos = DEFAULT_TOS;
+#endif
+  iph->tot_len = bpf_htons(pkt_bytes + sizeof(struct iphdr));
+  iph->daddr = daddr;
+  iph->saddr = saddr;
+  iph->ttl = DEFAULT_TTL;
+  ipv4_csum_inline(iph, &csum);
+  iph->check = csum;
+}
+
+__attribute__((__always_inline__)) static inline void create_v6_hdr(
+    struct ipv6hdr* ip6h,
+    __u8 tc,
+    __u32* saddr,
+    __u32* daddr,
+    __u16 payload_len,
+    __u8 proto) {
+  ip6h->version = 6;
+  memset(ip6h->flow_lbl, 0, sizeof(ip6h->flow_lbl));
+#ifdef COPY_INNER_PACKET_TOS
+  ip6h->priority = (tc & 0xF0) >> 4;
+  ip6h->flow_lbl[0] = (tc & 0x0F) << 4;
+#else
+  ip6h->priority = DEFAULT_TOS;
+#endif
+  ip6h->nexthdr = proto;
+  ip6h->payload_len = bpf_htons(payload_len);
+  ip6h->hop_limit = DEFAULT_TTL;
+  memcpy(ip6h->saddr.s6_addr32, saddr, 16);
+  memcpy(ip6h->daddr.s6_addr32, daddr, 16);
+}
+
+__attribute__((__always_inline__))
+static inline void create_udp_hdr(struct udphdr *udph, __u16 sport, __u16 dport,
+                                  __u16 len, __u16 csum) {
+  udph->source = sport;
+  udph->dest = bpf_htons(dport);
+  udph->len = bpf_htons(len);
+  udph->check = csum;
+}
+
+#endif // of __ENCAP_HELPERS_H

--- a/katran/lib/bpf/healthchecking_consts.h
+++ b/katran/lib/bpf/healthchecking_consts.h
@@ -1,0 +1,49 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __HEALTHCHECKING_CONSTS_H
+#define __HEALTHCHECKING_CONSTS_H
+
+#define CTRL_MAP_SIZE 4
+// position of ifindex of main interface inside hc ctrl array
+#define HC_MAIN_INTF_POSITION 3
+
+#define REDIRECT_EGRESS 0
+#define DEFAULT_TTL 64
+
+// Specify max packet size to avoid packets exceed mss (after encapsulation)
+#ifndef HC_MAX_PACKET_SIZE
+#define HC_MAX_PACKET_SIZE 1474
+#endif
+
+// position in stats map where we are storing generic counters.
+#define GENERIC_STATS_INDEX 0
+
+// code to indicate that packet should be futher processed by pipeline
+#define HC_FURTHER_PROCESSING -2
+
+// size of stats map.
+#define STATS_SIZE 1
+
+#define NO_FLAGS 0
+
+#define V6DADDR (1 << 0)
+
+#define HC_SRC_MAC_POS 0
+#define HC_DST_MAC_POS 1
+
+
+#endif // of __HEALTHCHECKING_CONSTS_H
+

--- a/katran/lib/bpf/healthchecking_helpers.h
+++ b/katran/lib/bpf/healthchecking_helpers.h
@@ -1,0 +1,95 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __HEALTHCHECKING_HELPERS_H
+#define __HEALTHCHECKING_HELPERS_H
+
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/pkt_cls.h>
+#include <linux/string.h>
+#include <linux/udp.h>
+#include <stdbool.h>
+
+#include "bpf.h"
+#include "bpf_helpers.h"
+
+#include "encap_helpers.h"
+
+#include "healthchecking_structs.h"
+#include "healthchecking_maps.h"
+
+
+__attribute__((__always_inline__)) static inline bool hc_encap_ipip(
+  struct __sk_buff *skb,
+  struct hc_real_definition *real,
+  struct ethhdr* ethh,
+  bool is_ipv6
+) {
+  struct hc_real_definition *src;
+  __u64 flags = 0;
+  __u16 pkt_len;
+  int adjust_len;
+  __u32 key;
+
+  pkt_len = skb->data_end - skb->data - sizeof(struct ethhdr);
+
+  if (real->flags == V6DADDR) {
+    __u8 proto = IPPROTO_IPV6;
+    key = V6_SRC_INDEX;
+    src = bpf_map_lookup_elem(&hc_pckt_srcs_map, &key);
+    if (!src) {
+      return false;
+    }
+    flags |= BPF_F_ADJ_ROOM_FIXED_GSO | BPF_F_ADJ_ROOM_ENCAP_L3_IPV6;
+    adjust_len = sizeof(struct ipv6hdr);
+    // new header would be inserted after MAC but before old L3 header
+    if(bpf_skb_adjust_room(skb, adjust_len, BPF_ADJ_ROOM_MAC, flags)) {
+      return false;
+    }
+    if ((skb->data + sizeof(struct ethhdr) + sizeof(struct ipv6hdr)) > skb->data_end) {
+      return false;
+    }
+    ethh = (void*)(long)skb->data;
+    ethh->h_proto = BE_ETH_P_IPV6;
+ 
+    struct ipv6hdr *ip6h = (void*)(long)skb->data + sizeof(struct ethhdr);
+    if (!is_ipv6) {
+      proto = IPPROTO_IPIP;
+    } 
+    create_v6_hdr(ip6h, DEFAULT_TOS, src->v6daddr, real->v6daddr, pkt_len, proto);
+  } else {
+    key = V4_SRC_INDEX;
+    src = bpf_map_lookup_elem(&hc_pckt_srcs_map, &key);
+    if (!src) {
+      return false;
+    }
+    flags |= BPF_F_ADJ_ROOM_FIXED_GSO | BPF_F_ADJ_ROOM_ENCAP_L3_IPV4;
+    adjust_len = sizeof(struct iphdr);
+    // new header would be inserted after MAC but before old L3 header
+    if(bpf_skb_adjust_room(skb, adjust_len, BPF_ADJ_ROOM_MAC, flags)) {
+      return false;
+    }
+    if ((skb->data + sizeof(struct ethhdr) + sizeof(struct iphdr)) > skb->data_end) {
+      return false;
+    }
+    struct iphdr *iph = (void*)(long)skb->data + sizeof(struct ethhdr);
+    create_v4_hdr(iph, DEFAULT_TOS, src->daddr, real->daddr, pkt_len, IPPROTO_IPIP);
+  }
+  return true;
+}
+
+#endif // of __HEALTHCHECKING_HELPERS_H

--- a/katran/lib/bpf/healthchecking_ipip.c
+++ b/katran/lib/bpf/healthchecking_ipip.c
@@ -101,7 +101,7 @@ int healthchecker(struct __sk_buff *skb)
 
   prog_stats = bpf_map_lookup_elem(&hc_stats_map, &stats_key);
   if (!prog_stats) {
-    return 1;
+    return TC_ACT_UNSPEC;
   }
 
   if (skb->mark == 0) {
@@ -112,14 +112,13 @@ int healthchecker(struct __sk_buff *skb)
   struct hc_real_definition *real = bpf_map_lookup_elem(&hc_reals_map,
                                                      &somark);
   if(!real) {
-    // some strange (w/ fwmark; but not a healthcheck)
-    // local packet to the VIP.
+    // some strange (w/ fwmark; but not a healthcheck) local packet
     prog_stats->pckts_skipped += 1;
     return TC_ACT_UNSPEC;
   }
 
   if (skb->len > MAX_PACKET_SIZE) {
-    // do not allow packets bigger than the specified size (typically adv-mss)
+    // do not allow packets bigger than the specified size
     prog_stats->pckts_dropped += 1;
     prog_stats->pckts_too_big += 1;
     return TC_ACT_SHOT;

--- a/katran/lib/bpf/healthchecking_kern.c
+++ b/katran/lib/bpf/healthchecking_kern.c
@@ -1,0 +1,126 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/pkt_cls.h>
+#include <linux/string.h>
+#include <linux/udp.h>
+
+#include "bpf.h"
+#include "bpf_helpers.h"
+
+#include "encap_helpers.h"
+
+#include "healthchecking_structs.h"
+#include "healthchecking_helpers.h"
+#include "healthchecking_maps.h"
+
+
+SEC("cls-hc")
+int healthchecker(struct __sk_buff *skb)
+{
+  __u32 stats_key = GENERIC_STATS_INDEX;
+  __u32 key = HC_MAIN_INTF_POSITION;
+  __u32 somark = skb->mark;
+  __u32 ifindex = 0;
+  __u64 flags = 0;
+  bool is_ipv6 = false;
+  int adjust_len = 0;
+  int ret = 0;
+  struct hc_stats* prog_stats;
+  struct ethhdr* ethh;
+  struct hc_mac *esrc, *edst;
+  struct hc_real_definition *src;
+  prog_stats = bpf_map_lookup_elem(&hc_stats_map, &stats_key);
+  if (!prog_stats) {
+    return TC_ACT_UNSPEC;
+  }
+
+  if (somark == 0) {
+    prog_stats->pckts_skipped += 1;
+    return TC_ACT_UNSPEC;
+  }
+
+  struct hc_real_definition *real = bpf_map_lookup_elem(&hc_reals_map,
+                                                     &somark);
+  if(!real) {
+    // some strange (w/ fwmark; but not a healthcheck) local packet
+    prog_stats->pckts_skipped += 1;
+    return TC_ACT_UNSPEC;
+  }
+
+  if (skb->len > HC_MAX_PACKET_SIZE) {
+    // do not allow packets bigger than the specified size
+    prog_stats->pckts_dropped += 1;
+    prog_stats->pckts_too_big += 1;
+    return TC_ACT_SHOT;
+  }
+
+  __u32* intf_ifindex = bpf_map_lookup_elem(&hc_ctrl_map, &key);
+  if (!intf_ifindex) {
+    // we dont have ifindex for main interface
+    // not much we can do without it. Drop packet so that hc will fail
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  key = HC_SRC_MAC_POS;
+  esrc = bpf_map_lookup_elem(&hc_pckt_macs, &key);
+  if (!esrc) {
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  key = HC_DST_MAC_POS;
+  edst = bpf_map_lookup_elem(&hc_pckt_macs, &key);
+  if (!edst) {
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  if ((skb->data + sizeof(struct ethhdr)) > skb->data_end) {
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  ethh = (void*)(long)skb->data;
+  if (ethh->h_proto == BE_ETH_P_IPV6) {
+    is_ipv6 = true;
+  }
+
+  // to prevent recursion, if encapsulated packet would run through this filter
+  skb->mark = 0;
+
+  if (!hc_encap_ipip(skb, real, ethh, is_ipv6)) {
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  if (skb->data + sizeof(struct ethhdr) > skb->data_end) {
+    prog_stats->pckts_dropped += 1;
+    return TC_ACT_SHOT;
+  }
+
+  ethh = (void*)(long)skb->data;
+  memcpy(ethh->h_source, esrc->mac, 6);
+  memcpy(ethh->h_dest, edst->mac, 6);
+
+  prog_stats->pckts_processed += 1;
+  return bpf_redirect(*intf_ifindex, REDIRECT_EGRESS);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/katran/lib/bpf/healthchecking_maps.h
+++ b/katran/lib/bpf/healthchecking_maps.h
@@ -1,0 +1,73 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __HEALTHCHECKING_MAPS_H
+#define __HEALTHCHECKING_MAPS_H
+
+#include "bpf.h"
+#include "bpf_helpers.h"
+
+#include "balancer_consts.h"
+#include "healthchecking_consts.h"
+#include "healthchecking_structs.h"
+
+struct bpf_map_def SEC("maps") hc_ctrl_map = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u32),
+    .max_entries = CTRL_MAP_SIZE,
+};
+BPF_ANNOTATE_KV_PAIR(hc_ctrl_map, __u32, __u32);
+
+struct bpf_map_def SEC("maps") hc_reals_map = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(struct hc_real_definition),
+    .max_entries = MAX_REALS,
+};
+BPF_ANNOTATE_KV_PAIR(hc_reals_map, __u32, struct hc_real_definition);
+
+struct bpf_map_def SEC("maps") hc_pckt_srcs_map = {
+  .type = BPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(__u32),
+  .value_size = sizeof(struct hc_real_definition),
+  .max_entries = 2,
+  .map_flags = NO_FLAGS,
+};
+BPF_ANNOTATE_KV_PAIR(hc_pckt_srcs_map, __u32, struct hc_real_definition);
+
+struct bpf_map_def SEC("maps") hc_pckt_macs = {
+  .type = BPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(__u32),
+  .value_size = sizeof(struct hc_mac),
+  .max_entries = 2,
+  .map_flags = NO_FLAGS,
+};
+BPF_ANNOTATE_KV_PAIR(hc_pckt_macs, __u32, struct hc_mac);
+
+// map which contains counters for monitoring
+struct bpf_map_def SEC("maps") hc_stats_map = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(struct hc_stats),
+    .max_entries = STATS_SIZE,
+    .map_flags = NO_FLAGS,
+};
+BPF_ANNOTATE_KV_PAIR(hc_stats_map, __u32, struct hc_stats);
+
+
+
+#endif // of __HEALTHCHECKING_MAPS_H
+

--- a/katran/lib/bpf/healthchecking_structs.h
+++ b/katran/lib/bpf/healthchecking_structs.h
@@ -1,0 +1,42 @@
+/*
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __HEALTHCHECKING_STRUCTS_H
+#define __HEALTHCHECKING_STRUCTS_H
+
+struct hc_real_definition {
+  union {
+    __be32 daddr;
+    __be32 v6daddr[4];
+  };
+  __u8 flags;
+};
+
+// struct to record packet level for counters for relevant events
+struct hc_stats {
+  __u64 pckts_processed;
+  __u64 pckts_dropped;
+  __u64 pckts_skipped;
+  __u64 pckts_too_big;
+};
+
+// struct to store mac address
+struct hc_mac {
+  __u8 mac[6];
+};
+
+#endif // of __HEALTHCHECKING_STRUCTS_H
+

--- a/katran/lib/testing/Base64Helpers.h
+++ b/katran/lib/testing/Base64Helpers.h
@@ -26,7 +26,7 @@ namespace katran {
 
 /**
  * helper class to do base64 encoding/decoding.
- * built to be as simple as possible. only intented to be used in XdpTester
+ * built to be as simple as possible. only intented to be used in BpfTester
  */
 class Base64Helpers {
  public:

--- a/katran/lib/testing/CMakeLists.txt
+++ b/katran/lib/testing/CMakeLists.txt
@@ -36,16 +36,17 @@ target_link_libraries(pcap_parser
     "${BOOST_SYSTEM}"
 )
 
-add_library(xdptester STATIC
-    XdpTester.h
-    XdpTester.cpp
+add_library(bpftester STATIC
+    BpfTester.h
+    BpfTester.cpp
     KatranTestFixtures.h
+    KatranHCTestFixtures.h
     KatranGueTestFixtures.h
     KatranOptionalTestFixtures.h
     KatranGueOptionalTestFixtures.h
 )
 
-target_link_libraries(xdptester
+target_link_libraries(bpftester
     "Folly::folly"
     "glog::glog"
     pcap_parser
@@ -72,7 +73,7 @@ add_executable(katran_tester katran_tester.cpp)
 
 target_link_libraries(katran_tester
   katranlb
-  xdptester
+  bpftester
   ${GFLAGS}
   ${GTEST}
 )

--- a/katran/lib/testing/KatranHCTestFixtures.h
+++ b/katran/lib/testing/KatranHCTestFixtures.h
@@ -1,0 +1,91 @@
+// @nolint
+/* 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+#include <string>
+#include <vector>
+#include <utility>
+#include <bpf/bpf.h>
+
+namespace katran {
+namespace testing {
+/**
+ * input packets has been generated with scapy. above each of em you can find
+ * a command which has been used to do so.
+ *
+ * format of the input data: <string, string>; 1st string is a base64 encoded
+ * packet. 2nd string is test's description
+ *
+ * format of the output data: <string, string>; 1st string is a base64 encoded
+ * packet which we are expecting to see after bpf program's run.
+ * 2nd string = bpf's program return code.
+ *
+ * to create pcap w/ scapy:
+ * 1) create packets
+ * 2) pckts = [ <created packets from above> ]
+ * 3) wrpcap(<path_to_file>, pckts)
+ */
+
+const std::vector<struct __sk_buff> getInputCtxsForHcTest() {
+    std::vector<struct __sk_buff> v;
+    for (int i = 0 ; i < 3 ; i++) {
+        struct __sk_buff skb;
+        skb.mark = i;
+        v.push_back(skb);
+    }
+    return v;
+};
+
+const std::vector<std::pair<std::string, std::string>> inputHCTestFixtures = {
+  //1
+  {
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
+    "v4 packet. no fwmark"
+  },
+  //2
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "v4 packet. fwmark 1"
+  },
+  //3
+  {
+    //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "v4 packet. fwmkark 2"
+  },
+};
+
+const std::vector<std::pair<std::string, std::string>> outputHCTestFixtures = {
+  //1
+  {
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
+    "TC_ACT_UNSPEC"
+  },
+  //2
+  {
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "TC_ACT_UNSPEC"
+  },
+  //3
+  {
+    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
+    "TC_ACT_UNSPEC"
+  },
+};
+} // namespace testing
+} // namespace katran


### PR DESCRIPTION
Big diff. Major changes:
- renaming XdpTester to BpfTester + adding features to unittest
BPF_PROG_TYPE_SCHED_CLS (TC bpf).
- adding into katran tester fixtures for healthchecking bpf program
(right now input and output are exactly the same. for now it is
being used either to make sure that prog is loaded and running +
somark in bpf program could be manually changed to some static value
instead of somark=skb->mark (this is till
https://www.spinics.net/lists/netdev/msg620553.html would be available
in vanila kernel)
- adding new healthchecking bpf program (this one forced to reshuffle
some existing code, so existing helpers would be bpf program agnostic
(e.g. before they were including balancer_maps etc)). the new
healthchecking program allow to directly create encapsulation
of the healthcheck packet instead of relying on ip4 and ipv6 tunnel
interfaces w/ external flag set.

Tested-By: katran_tester. for healthchecking somark were manually set to
2 and 3 (to force ipip and ip(4)ip6 healthchecks generation).

ipip:
```
23:12:37.392524 01:00:00:00:00:00 > 02:00:00:00:00:00, ethertype IPv4 (0x0800), length 57: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:12:37.392535 00:ff:de:ad:be:af > 00:00:de:ad:be:af, ethertype IPv4 (0x0800), length 77: (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto IPIP (4), length 63)
    10.0.13.37 > 10.0.0.2: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:12:37.392655 01:00:00:00:00:00 > 02:00:00:00:00:00, ethertype IPv4 (0x0800), length 69: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:12:37.392664 00:ff:de:ad:be:af > 00:00:de:ad:be:af, ethertype IPv4 (0x0800), length 89: (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto IPIP (4), length 75)
    10.0.13.37 > 10.0.0.2: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
```

ip(4)ip6
```
23:17:54.987396 01:00:00:00:00:00 > 02:00:00:00:00:00, ethertype IPv4 (0x0800), length 57: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:17:54.987408 00:ff:de:ad:be:af > 00:00:de:ad:be:af, ethertype IPv6 (0x86dd), length 97: (hlim 64, next-header IPIP (4) payload length: 43) fc00:2307::1337 > fc00::1: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:17:54.987422 01:00:00:00:00:00 > 02:00:00:00:00:00, ethertype IPv4 (0x0800), length 69: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:17:54.987426 00:ff:de:ad:be:af > 00:00:de:ad:be:af, ethertype IPv6 (0x86dd), length 109: (hlim 64, next-header IPIP (4) payload length: 55) fc00:2307::1337 > fc00::1: (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:17:54.987439 01:00:00:00:00:00 > 02:00:00:00:00:00, ethertype IPv6 (0x86dd), length 89: (hlim 64, next-header TCP (6) payload length: 35) fc00:2::1.31337 > fc00:1::1.80: Flags [.], cksum 0xfd4f (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:17:54.987443 00:ff:de:ad:be:af > 00:00:de:ad:be:af, ethertype IPv6 (0x86dd), length 129: (hlim 64, next-header IPv6 (41) payload length: 75) fc00:2307::1337 > fc00::1: (hlim 64, next-header TCP (6) payload length: 35) fc00:2::1.31337 > fc00:1::1.80: Flags [.], cksum 0xfd4f (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
```