### PR TITLE
[katran]: adding support for gue healthchecks

### DIFF
--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -286,9 +286,11 @@
 #ifdef GUE_ENCAP
 #define PCKT_ENCAP_V4 gue_encap_v4
 #define PCKT_ENCAP_V6 gue_encap_v6
+#define HC_ENCAP hc_encap_gue
 #else
 #define PCKT_ENCAP_V4 encap_v4
 #define PCKT_ENCAP_V6 encap_v6
+#define HC_ENCAP hc_encap_ipip
 #endif
 
 

--- a/katran/lib/bpf/healthchecking_helpers.h
+++ b/katran/lib/bpf/healthchecking_helpers.h
@@ -92,4 +92,76 @@ __attribute__((__always_inline__)) static inline bool hc_encap_ipip(
   return true;
 }
 
+__attribute__((__always_inline__)) static inline __u16 gue_sport(__u32 seed) {
+  return (__u16)((seed ^ (seed >> 16)) & 0xFFFF);
+}
+
+__attribute__((__always_inline__)) static inline bool hc_encap_gue(
+  struct __sk_buff *skb,
+  struct hc_real_definition *real,
+  struct ethhdr* ethh,
+  bool is_ipv6
+) {
+  struct hc_real_definition *src;
+  __u64 flags = 0;
+  __u16 pkt_len;
+  __u16 sport;
+  int adjust_len;
+  __u32 key;
+
+  pkt_len = skb->data_end - skb->data - sizeof(struct ethhdr);
+
+  if (real->flags == V6DADDR) {
+    sport = gue_sport(real->v6daddr[0] | real->v6daddr[3]);
+    __u8 proto = IPPROTO_IPV6;
+    key = V6_SRC_INDEX;
+    src = bpf_map_lookup_elem(&hc_pckt_srcs_map, &key);
+    if (!src) {
+      return false;
+    }
+    flags |= BPF_F_ADJ_ROOM_FIXED_GSO | BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 | BPF_F_ADJ_ROOM_ENCAP_L4_UDP;
+    adjust_len = sizeof(struct ipv6hdr) + sizeof(struct udphdr);
+    // new headers would be inserted after MAC but before old L3 header
+    if(bpf_skb_adjust_room(skb, adjust_len, BPF_ADJ_ROOM_MAC, flags)) {
+      return false;
+    }
+    if ((skb->data + sizeof(struct ethhdr) + sizeof(struct ipv6hdr) + 
+        sizeof(struct udphdr)) > skb->data_end) {
+      return false;
+    }
+    ethh = (void*)(long)skb->data;
+    ethh->h_proto = BE_ETH_P_IPV6;
+ 
+    struct ipv6hdr *ip6h = (void*)(long)skb->data + sizeof(struct ethhdr);
+    struct udphdr *udph = (void*)ip6h + sizeof(struct ipv6hdr);
+    pkt_len += sizeof(struct udphdr);
+    create_udp_hdr(udph, sport, GUE_DPORT, pkt_len, 0);
+    create_v6_hdr(ip6h, DEFAULT_TOS, src->v6daddr, real->v6daddr, pkt_len, IPPROTO_UDP);
+  } else {
+    sport = gue_sport(real->daddr);
+    key = V4_SRC_INDEX;
+    src = bpf_map_lookup_elem(&hc_pckt_srcs_map, &key);
+    if (!src) {
+      return false;
+    }
+    flags |= BPF_F_ADJ_ROOM_FIXED_GSO | BPF_F_ADJ_ROOM_ENCAP_L3_IPV4 | BPF_F_ADJ_ROOM_ENCAP_L4_UDP;
+    adjust_len = sizeof(struct iphdr) + sizeof(struct udphdr);
+    // new headers would be inserted after MAC but before old L3 header
+    if(bpf_skb_adjust_room(skb, adjust_len, BPF_ADJ_ROOM_MAC, flags)) {
+      return false;
+    }
+    if ((skb->data + sizeof(struct ethhdr) + sizeof(struct iphdr) +
+        sizeof(struct udphdr)) > skb->data_end) {
+      return false;
+    }
+    struct iphdr *iph = (void*)(long)skb->data + sizeof(struct ethhdr);
+    struct udphdr *udph = (void*)iph + sizeof(struct iphdr);
+    pkt_len += sizeof(struct udphdr);
+    create_udp_hdr(udph, sport, GUE_DPORT, pkt_len, 0);
+    create_v4_hdr(iph, DEFAULT_TOS, src->daddr, real->daddr, pkt_len, IPPROTO_UDP);
+  }
+  return true;
+}
+
+
 #endif // of __HEALTHCHECKING_HELPERS_H

--- a/katran/lib/bpf/healthchecking_kern.c
+++ b/katran/lib/bpf/healthchecking_kern.c
@@ -105,7 +105,7 @@ int healthchecker(struct __sk_buff *skb)
   // to prevent recursion, if encapsulated packet would run through this filter
   skb->mark = 0;
 
-  if (!hc_encap_ipip(skb, real, ethh, is_ipv6)) {
+  if (!HC_ENCAP(skb, real, ethh, is_ipv6)) {
     prog_stats->pckts_dropped += 1;
     return TC_ACT_SHOT;
   }

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,7 +3,7 @@
 ### xdpdump
 tcpdump like tool, which is working in XDP environment
 
-### tcpdump_ipip_helper
+### tcpdump_encap_helper
 helper script to create filters for tcpdump based on inner ip header
 
 ### start_katran

--- a/tools/tcpdump_encap_helper/README.md
+++ b/tools/tcpdump_encap_helper/README.md
@@ -1,13 +1,15 @@
-# tcpdump_ipip_helper
+# tcpdump_encap_helper
 this is a simple script which helps to create filters for tcpdump to match on
-fields from inner ip packet. currently we can match src/dst/protocol/ports
+fields from inner ip packet. currently we can match src/dst/protocol/ports.
+by default we are building filter for IPIP encapsulation. -gue flag could be
+used to create filters based on GUE encapsulation 
 ### example of usage.
 ```
-usage: tcpdump_ipip_helper.py [-h] [-m {4,6,46}] [-s SRC] [-d DST] [-p PROTO]
+usage: tcpdump_encap_helper.py [-h] [-m {4,6,46}] [-s SRC] [-d DST] [-p PROTO]
                               [--sport SPORT] [--dport DPORT]
 
 this is a tool which helps to create a filter to match fields from internal
-header of IPIP packet
+header of IPIP/GUE packet
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -31,7 +33,7 @@ create a filter to match inner packet w/ dst 10.0.0.1 TCP and destination
 port 22. for ipv4inipv6 encapsulation:
 
 ```
-./tcpdump_ipip_helper.py -m 4 -d 10.0.0.1 -p 6 --dport 22
+./tcpdump_encap_helper.py -m 4 -d 10.0.0.1 -p 6 --dport 22
 "((ip[36:4] == 0x0A000001 ) and (ip[29:1] == 6 ) and (ip[42:2] == 22 ))"
 ```
 
@@ -44,6 +46,6 @@ tcpdump -ni eth0 "((ip[36:4] == 0x0A000001 ) and (ip[29:1] == 6 ) and (ip[42:2] 
 create a filter to match inner packet w/ dst fc00::1 UDP and source port 10000
 
 ```
-./tcpdump_ipip_helper.py -m 6 -d fc00::1 -p 17 --sport 10000
+./tcpdump_encap_helper.py -m 6 -d fc00::1 -p 17 --sport 10000
 "((ip6[64:4] == 0xFC000000 ) and (ip6[68:4] == 0x0000 ) and (ip6[72:4] == 0x0000 ) and (ip6[76:4] == 0x0001 ) and (ip6[46:1] == 17 ) and (ip6[80:2] == 10000 ))"
 ```


### PR DESCRIPTION
after reworking ipip healthchecks adding support for gue based
healthchecks. GUE_ENCAP flag controls the mode, which is going to be
used in healthchecker.

Tested-By: katran_tester w/ manually changing somark in
healthchecking_kern to value 1 and 3 (to force v4 or v6 backend;
while upstream kernels does not have a patch to run bpf_prog_test_run
w/ custom somark)

```
v4:
22:10:36.937497 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 71)
    10.0.13.37.2561 > 10.0.0.1.6080: [no cksum] UDP, length 43
22:10:36.937506 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
22:10:36.937510 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 83)
    10.0.13.37.2561 > 10.0.0.1.6080: [no cksum] UDP, length 55

v6:
22:12:37.378422 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
22:12:37.378434 IP6 (hlim 64, next-header UDP (17) payload length: 51) fc00:2307::1337.64513 > fc00::1.6080: [bad udp cksum 0x0000 -> 0x8b20!] UDP, length 43
22:12:37.378447 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
22:12:37.378451 IP6 (hlim 64, next-header UDP (17) payload length: 63) fc00:2307::1337.64513 > fc00::1.6080: [bad udp cksum 0x0000 -> 0x8b09!] UDP, length 55
22:12:37.378459 IP6 (hlim 64, next-header TCP (6) payload length: 35) fc00:2::1.31337 > fc00:1::1.80: Flags [.], cksum 0xfd4f (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
22:12:37.378464 IP6 (hlim 64, next-header UDP (17) payload length: 83) fc00:2307::1337.64513 > fc00::1.6080: [bad udp cksum 0x0000 -> 0x570b!] UDP, length 75
```

also tested in VM env to make sure that such packets are accepted by
remote host w/ gue decap interface configured

also i've modified/renamed tcpdump_encap_helper tool to be able to
create a filter for GUE encapped packets