### PR TITLE
[katran]: fixing build script

### DIFF
--- a/build_bpf_modules_opensource.sh
+++ b/build_bpf_modules_opensource.sh
@@ -47,6 +47,7 @@ while getopts ":hb:s:m" arg; do
       ;;
   esac
 done
+shift $((OPTIND -1))
 
 # Validate required parameters
 if [ -z "${BUILD_DIR-}" ] ; then


### PR DESCRIPTION
w/o this diff build_katran is using -b and -s options w/
build_bpf_modules_opensource.sh during build_katran.sh step.
it does not remove them from argument lists after parsing and passing
down to make command cousing and issue like:
```
DDEBUG -D__KERNEL__ -Wno-unused-value -Wno-pointer-sign \
        -Wno-compare-distinct-pointer-types \
        -O2 -emit-llvm -c -g bpf/balancer_kern.c -o -| /home/tehnerd/katran/_build/deps/clang/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/llc -march=bpf -filetype=obj -o bpf/balancer_kern.o
clang-8: error: unsupported option '-b /home/tehnerd/katran/_build'
clang-8: warning: /home/tehnerd/katran: 'linker' input unused [-Wunused-command-line-argument]
```

fixing this by shifting argument list after parsing and before passing
this into make