### PR TITLE
adding helper to setup clsact qdisk

### DIFF
--- a/katran/lib/BpfAdapter.cpp
+++ b/katran/lib/BpfAdapter.cpp
@@ -381,7 +381,7 @@ int BpfAdapter::getBpfMapMaxSize(const std::string& name) {
 
 int BpfAdapter::getBpfMapUsedSize(const std::string& name) {
   int num_entries = 0, err = 0;
-  void *prev_key = nullptr;
+  void* prev_key = nullptr;
   struct bpf_map_info info;
   int fd = getMapFdByName(name);
   if (fd < 0) {
@@ -470,6 +470,7 @@ int BpfAdapter::addTcBpfFilter(
     const std::string& bpf_name,
     const uint32_t priority,
     const int direction) {
+  addClsActQD(ifindex);
   return genericAttachBpfProgToTc(
       prog_fd, ifindex, bpf_name, priority, direction);
 }
@@ -570,6 +571,11 @@ int BpfAdapter::modifyTcBpfFilter(
   unsigned int seq = static_cast<unsigned int>(std::time(nullptr));
   auto msg = NetlinkMessage::TC(
       seq, cmd, flags, priority, prog_fd, ifindex, bpf_name, direction);
+  return NetlinkRoundtrip(msg);
+}
+
+int BpfAdapter::addClsActQD(const unsigned int ifindex) {
+  auto msg = NetlinkMessage::QD(ifindex);
   return NetlinkRoundtrip(msg);
 }
 

--- a/katran/lib/BpfAdapter.h
+++ b/katran/lib/BpfAdapter.h
@@ -190,7 +190,6 @@ class BpfAdapter {
    */
   static int getPinnedBpfObject(const std::string& path);
 
-
   /**
    * @param int fd of the object (e.g. map)
    * @param bpf_map_info* pointer of pre-allocated bpf map info to populate
@@ -634,6 +633,11 @@ class BpfAdapter {
       const unsigned int ifindex,
       const std::string& bpf_name,
       const int direction = BPF_TC_INGRESS);
+
+  /**
+   * helper function to add clsact qdisk to interface for healthchecking
+   */
+  static int addClsActQD(const unsigned int ifindex);
 
   /**
    * Generic wrapper to add bpf prog to tc.

--- a/katran/lib/Netlink.cpp
+++ b/katran/lib/Netlink.cpp
@@ -180,8 +180,6 @@ NetlinkMessage NetlinkMessage::QD(unsigned ifindex) {
 
   struct nlmsghdr* nlh;
   struct tcmsg* tc;
-  uint32_t protocol = 0;
-  unsigned int bpfFlags = TCA_BPF_FLAG_ACT_DIRECT;
 
   // Construct netlink message header
   nlh = mnl_nlmsg_put_header(buf);

--- a/katran/lib/Netlink.h
+++ b/katran/lib/Netlink.h
@@ -24,7 +24,7 @@ namespace katran {
 class NetlinkMessage {
  public:
   /**
-   * Constructs a netlink message used tocontrol the lifecycle of a BPF
+   * Constructs a netlink message used to control the lifecycle of a BPF
    * program on the network scheduler.
    *
    * @param seq          Sequence number for message.
@@ -46,6 +46,14 @@ class NetlinkMessage {
       unsigned ifindex,
       const std::string& bpf_name,
       int direction);
+
+  /**
+   * Constructs a netlink message used to attach clsact qdisk
+   * to specified interface
+   *
+   * @param ifindex      Network interface index
+   */
+  static NetlinkMessage QD(unsigned ifindex);
 
   /**
    * Constructs a netlink message used to control the lifecycle of an XDP BPF


### PR DESCRIPTION
before this diff, if bpf based healthchecks were used, it were required for operator to install clsact qdisk w/ a help of external tools (e.g. by running `sudo tc qd add  dev <intf> clsact` shell command). otherwise TC bpf program were failing to be installed. in this diff BpfAdapter were modified in a way, that it would try to unconditionally install clsact qdisk, before trying to attach TC bpf program.
If clsact QD already were installed - netlink layer would return error (which we would ignore and proceed to TC installation as if nothing had happened).

Tests:
cli output before/after starting katran:
```
tehnerd@nuke:~/projects/sdd/projects/katran$ tc qd show dev wlp3s0
qdisc mq 0: root 
qdisc fq_codel 0: parent :4 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :3 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :2 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :1 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
tehnerd@nuke:~/projects/sdd/projects/katran$ tc qd show dev wlp3s0
qdisc mq 0: root 
qdisc fq_codel 0: parent :4 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :3 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :2 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc fq_codel 0: parent :1 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn 
qdisc clsact ffff: parent ffff:fff1    <<<< CLSACT qdisk were added
```

2nd start of katran (when we already have qd installed):
```
...
E0519 21:05:26.150229 22225 BpfLoader.cpp:87] Can't find map w/ name: hc_pckt_srcs_map
----------------        ------------------
|  0000000048  |        | message length |
| 00036 | R-A- |        |  type | flags  |
|  0000000000  |        | sequence number|
|  0000000000  |        |     port ID    |
----------------        ------------------
| 00 00 00 00  |        |  extra header  |
| 03 00 00 00  |        |  extra header  |
| 00 00 ff ff  |        |  extra header  |
| f1 ff ff ff  |        |  extra header  |
|00011|--|00001|        |len |flags| type|
| 63 6c 73 61  |        |      data      |       c l s a
| 63 74 00 00  |        |      data      |       c t    
----------------        ------------------
E0519 21:05:26.150315 22225 BpfAdapter.cpp:220] Error receiving netlink message: File exists [17]  <<< ERROR line about qd already installed
...
```

