### PR TITLE
allow to have multiple hashing functions

### DIFF
--- a/katran/lib/CHHelpers.cpp
+++ b/katran/lib/CHHelpers.cpp
@@ -14,79 +14,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "CHHelpers.h"
-
-#include "MurmurHash3.h"
-
+#include "katran/lib/CHHelpers.h"
+#include "katran/lib/MaglevHash.h"
 namespace katran {
-
-namespace {
-constexpr uint32_t kHashSeed0 = 0;
-constexpr uint32_t kHashSeed1 = 2307;
-constexpr uint32_t kHashSeed2 = 42;
-constexpr uint32_t kHashSeed3 = 2718281828;
-} // namespace
-
-void CHHelpers::genMaglevPermuation(
-    std::vector<uint32_t>& permutation,
-    const Endpoint endpoint,
-    const uint32_t pos,
-    const uint32_t ring_size) {
-  auto offset_hash = MurmurHash3_x64_64(endpoint.hash, kHashSeed2, kHashSeed0);
-
-  auto offset = offset_hash % ring_size;
-
-  auto skip_hash = MurmurHash3_x64_64(endpoint.hash, kHashSeed3, kHashSeed1);
-
-  auto skip = (skip_hash % (ring_size - 1)) + 1;
-
-  permutation[2 * pos] = offset;
-  permutation[2 * pos + 1] = skip;
-};
-
-std::vector<int> CHHelpers::GenerateMaglevHash(
-    std::vector<Endpoint> endpoints,
-    const uint32_t ring_size) {
-  std::vector<int> result(ring_size, -1);
-
-  if (endpoints.size() == 0) {
-    return result;
-  } else if (endpoints.size() == 1) {
-    for (auto& v : result) {
-      v = endpoints[0].num;
-    }
-    return result;
+std::unique_ptr<ConsistentHash> CHHelpers::hashFunctionsFactory(
+    HashFunctions func) {
+  switch (func) {
+    case HashFunctions::Maglev:
+      return std::make_unique<MaglevHash>();
+    default:
+      // fallback to default maglev's implementation
+      return std::make_unique<MaglevHash>();
   }
-
-  uint32_t runs = 0;
-  std::vector<uint32_t> permutation(endpoints.size() * 2, 0);
-  std::vector<uint32_t> next(endpoints.size(), 0);
-
-  for (int i = 0; i < endpoints.size(); i++) {
-    genMaglevPermuation(permutation, endpoints[i], i, ring_size);
-  }
-
-  for (;;) {
-    for (int i = 0; i < endpoints.size(); i++) {
-      auto offset = permutation[2 * i];
-      auto skip = permutation[2 * i + 1];
-      // our realization of "weights" for maglev's hash.
-      for (int j = 0; j < endpoints[i].weight; j++) {
-        auto cur = (offset + next[i] * skip) % ring_size;
-        while (result[cur] >= 0) {
-          next[i] += 1;
-          cur = (offset + next[i] * skip) % ring_size;
-        }
-        result[cur] = endpoints[i].num;
-        next[i] += 1;
-        runs++;
-        if (runs == ring_size) {
-          return result;
-        }
-      }
-      endpoints[i].weight = 1;
-    }
-  }
-};
-
+}
 } // namespace katran

--- a/katran/lib/CHHelpers.cpp
+++ b/katran/lib/CHHelpers.cpp
@@ -17,10 +17,9 @@
 #include "katran/lib/CHHelpers.h"
 #include "katran/lib/MaglevHash.h"
 namespace katran {
-std::unique_ptr<ConsistentHash> CHHelpers::hashFunctionsFactory(
-    HashFunctions func) {
+std::unique_ptr<ConsistentHash> CHFactory::make(HashFunction func) {
   switch (func) {
-    case HashFunctions::Maglev:
+    case HashFunction::Maglev:
       return std::make_unique<MaglevHash>();
     default:
       // fallback to default maglev's implementation

--- a/katran/lib/CHHelpers.h
+++ b/katran/lib/CHHelpers.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace katran {
@@ -36,37 +37,33 @@ struct Endpoint {
 };
 
 /**
- * This class implements generic helpers to build Consisten hash rings for
- * specified Endpoints.
+ * ConsistentHash implements interface, which is used by CHHelpers class to
+ * generate hash ring
  */
-class CHHelpers {
+class ConsistentHash {
  public:
   /**
    * @param std::vector<Endpoints>& endpoints, which will be used for CH
    * @param uint32_t ring_size size of the CH ring
    * @return std::vector<int> vector, which describe CH ring.
-   * it's size would be ring_size and
-   * which will have Endpoints.num as a values.
-   *
-   * this helper function would implement Maglev's hash algo
-   * (more info: http://research.google.com/pubs/pub44824.html ; section 3.4)
-   * ring_size must be prime number.
-   * this function could throw because allocation for vector could fail.
    */
-  static std::vector<int> GenerateMaglevHash(
+  virtual std::vector<int> generateHashRing(
       std::vector<Endpoint> endpoints,
-      const uint32_t ring_size = kDefaultChRingSize);
+      const uint32_t ring_size = kDefaultChRingSize) = 0;
+};
 
- private:
-  /**
-   * helper function which will generate Maglev's permutation array for
-   * specified endpoint on specified possition
-   */
-  static void genMaglevPermuation(
-      std::vector<uint32_t>& permutation,
-      const Endpoint endpoint,
-      const uint32_t pos,
-      const uint32_t ring_size);
+enum class HashFunctions {
+  Maglev,
+};
+
+/**
+ * This class implements generic helpers to build Consisten hash rings for
+ * specified Endpoints.
+ */
+class CHHelpers {
+ public:
+  static std::unique_ptr<ConsistentHash> hashFunctionsFactory(
+      HashFunctions func);
 };
 
 } // namespace katran

--- a/katran/lib/CHHelpers.h
+++ b/katran/lib/CHHelpers.h
@@ -37,7 +37,7 @@ struct Endpoint {
 };
 
 /**
- * ConsistentHash implements interface, which is used by CHHelpers class to
+ * ConsistentHash implements interface, which is used by CHFactory class to
  * generate hash ring
  */
 class ConsistentHash {
@@ -50,20 +50,23 @@ class ConsistentHash {
   virtual std::vector<int> generateHashRing(
       std::vector<Endpoint> endpoints,
       const uint32_t ring_size = kDefaultChRingSize) = 0;
+  virtual ~ConsistentHash(){};
 };
 
-enum class HashFunctions {
+enum class HashFunction {
   Maglev,
 };
 
 /**
- * This class implements generic helpers to build Consisten hash rings for
+ * This class implements generic helpers to build Consistent hash rings for
  * specified Endpoints.
  */
-class CHHelpers {
+class CHFactory {
  public:
-  static std::unique_ptr<ConsistentHash> hashFunctionsFactory(
-      HashFunctions func);
+  /**
+   * @param HashFunction func to use for hash ring generation
+   */
+  static std::unique_ptr<ConsistentHash> make(HashFunction func);
 };
 
 } // namespace katran

--- a/katran/lib/CMakeLists.txt
+++ b/katran/lib/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(murmur3 STATIC
 add_library(chhelpers STATIC
     CHHelpers.h
     CHHelpers.cpp
+    MaglevHash.h
+    MaglevHash.cpp
 )
 
 target_link_libraries(chhelpers murmur3)

--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -684,7 +684,7 @@ bool KatranLb::addVip(const VipKey& vip, const uint32_t flags) {
   return true;
 }
 
-bool KatranLb::changeHashFunctionForVip(const VipKey& vip, HashFunctions func) {
+bool KatranLb::changeHashFunctionForVip(const VipKey& vip, HashFunction func) {
   if (config_.disableForwarding) {
     LOG(ERROR) << "Ignoring addVip call on non-forwarding instance";
     return false;

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -162,11 +162,11 @@ class KatranLb {
 
   /**
    * @param VipKey vip to modify
-   * @param HashFunctions func to generate hash ring
+   * @param HashFunction func to generate hash ring
    *
    * helper function to change hash ring's hash function
    */
-  bool changeHashFunctionForVip(const VipKey& vip, HashFunctions func);
+  bool changeHashFunctionForVip(const VipKey& vip, HashFunction func);
 
   /**
    * @param VipKey vip to get flags from

--- a/katran/lib/KatranLb.h
+++ b/katran/lib/KatranLb.h
@@ -161,6 +161,14 @@ class KatranLb {
   bool modifyVip(const VipKey& vip, uint32_t flag, bool set = true);
 
   /**
+   * @param VipKey vip to modify
+   * @param HashFunctions func to generate hash ring
+   *
+   * helper function to change hash ring's hash function
+   */
+  bool changeHashFunctionForVip(const VipKey& vip, HashFunctions func);
+
+  /**
    * @param VipKey vip to get flags from
    * @return uint32_t flags of this vip
    *
@@ -697,6 +705,13 @@ class KatranLb {
    * acheaving this by register itself in internal programs array
    */
   void enableRecirculation();
+
+  /**
+   * program hash ring in forwarding plane
+   */
+  void programHashRing(
+      const std::vector<RealPos>& chPositions,
+      const uint32_t vipNum);
 
   /**
    * main configurations of katran

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include "katran/lib/MonitoringStructs.h"
+#include "katran/lib/CHHelpers.h"
 
 namespace katran {
 
@@ -150,6 +151,7 @@ struct KatranMonitorConfig {
  * @param katranSrcV4 string ipv4 source address for GUE packets
  * @param katranSrcV6 string ipv6 source address for GUE packets
  * @param std::vector<uint8_t> localMac mac address of local server
+ * @param HashFunctions hashFunction to create hash ring
  *
  * note about rootMapPath and rootMapPos:
  * katran has two modes of operation.
@@ -197,6 +199,7 @@ struct KatranConfig {
   std::string katranSrcV4 = kAddressNotSpecified;
   std::string katranSrcV6 = kAddressNotSpecified;
   std::vector<uint8_t> localMac;
+  HashFunctions hashFunction = HashFunctions::Maglev;
 };
 
 /**

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -20,8 +20,8 @@
 #include <functional>
 #include <string>
 #include <vector>
-#include "katran/lib/MonitoringStructs.h"
 #include "katran/lib/CHHelpers.h"
+#include "katran/lib/MonitoringStructs.h"
 
 namespace katran {
 
@@ -151,7 +151,7 @@ struct KatranMonitorConfig {
  * @param katranSrcV4 string ipv4 source address for GUE packets
  * @param katranSrcV6 string ipv6 source address for GUE packets
  * @param std::vector<uint8_t> localMac mac address of local server
- * @param HashFunctions hashFunction to create hash ring
+ * @param HashFunction hashFunction to create hash ring
  *
  * note about rootMapPath and rootMapPos:
  * katran has two modes of operation.
@@ -199,7 +199,7 @@ struct KatranConfig {
   std::string katranSrcV4 = kAddressNotSpecified;
   std::string katranSrcV6 = kAddressNotSpecified;
   std::vector<uint8_t> localMac;
-  HashFunctions hashFunction = HashFunctions::Maglev;
+  HashFunction hashFunction = HashFunction::Maglev;
 };
 
 /**

--- a/katran/lib/MaglevHash.cpp
+++ b/katran/lib/MaglevHash.cpp
@@ -1,0 +1,75 @@
+#include <katran/lib/MaglevHash.h>
+#include "katran/lib/MurmurHash3.h"
+
+namespace katran {
+
+namespace {
+constexpr uint32_t kHashSeed0 = 0;
+constexpr uint32_t kHashSeed1 = 2307;
+constexpr uint32_t kHashSeed2 = 42;
+constexpr uint32_t kHashSeed3 = 2718281828;
+} // namespace
+
+void MaglevHash::genMaglevPermuation(
+    std::vector<uint32_t>& permutation,
+    const Endpoint endpoint,
+    const uint32_t pos,
+    const uint32_t ring_size) {
+  auto offset_hash = MurmurHash3_x64_64(endpoint.hash, kHashSeed2, kHashSeed0);
+
+  auto offset = offset_hash % ring_size;
+
+  auto skip_hash = MurmurHash3_x64_64(endpoint.hash, kHashSeed3, kHashSeed1);
+
+  auto skip = (skip_hash % (ring_size - 1)) + 1;
+
+  permutation[2 * pos] = offset;
+  permutation[2 * pos + 1] = skip;
+};
+
+std::vector<int> MaglevHash::generateHashRing(
+    std::vector<Endpoint> endpoints,
+    const uint32_t ring_size) {
+  std::vector<int> result(ring_size, -1);
+
+  if (endpoints.size() == 0) {
+    return result;
+  } else if (endpoints.size() == 1) {
+    for (auto& v : result) {
+      v = endpoints[0].num;
+    }
+    return result;
+  }
+
+  uint32_t runs = 0;
+  std::vector<uint32_t> permutation(endpoints.size() * 2, 0);
+  std::vector<uint32_t> next(endpoints.size(), 0);
+
+  for (int i = 0; i < endpoints.size(); i++) {
+    genMaglevPermuation(permutation, endpoints[i], i, ring_size);
+  }
+
+  for (;;) {
+    for (int i = 0; i < endpoints.size(); i++) {
+      auto offset = permutation[2 * i];
+      auto skip = permutation[2 * i + 1];
+      // our realization of "weights" for maglev's hash.
+      for (int j = 0; j < endpoints[i].weight; j++) {
+        auto cur = (offset + next[i] * skip) % ring_size;
+        while (result[cur] >= 0) {
+          next[i] += 1;
+          cur = (offset + next[i] * skip) % ring_size;
+        }
+        result[cur] = endpoints[i].num;
+        next[i] += 1;
+        runs++;
+        if (runs == ring_size) {
+          return result;
+        }
+      }
+      endpoints[i].weight = 1;
+    }
+  }
+};
+
+} // namespace katran

--- a/katran/lib/MaglevHash.h
+++ b/katran/lib/MaglevHash.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "katran/lib/CHHelpers.h"
+
+namespace katran {
+
+/**
+ * MaglevHash class implements Maglev's hash algo
+ * (more info: http://research.google.com/pubs/pub44824.html ; section 3.4)
+ */
+class MaglevHash : public ConsistentHash {
+ public:
+  MaglevHash(){};
+  /**
+   * @param std::vector<Endpoints>& endpoints, which will be used for CH
+   * @param uint32_t ring_size size of the CH ring
+   * @return std::vector<int> vector, which describe CH ring.
+   * it's size would be ring_size and
+   * which will have Endpoints.num as a values.
+   * ring_size must be prime number.
+   * this function could throw because allocation for vector could fail.
+   */
+  std::vector<int> generateHashRing(
+      std::vector<Endpoint>,
+      const uint32_t ring_size = kDefaultChRingSize) override;
+
+ private:
+  /**
+   * helper function which will generate Maglev's permutation array for
+   * specified endpoint on specified possition
+   */
+  static void genMaglevPermuation(
+      std::vector<uint32_t>& permutation,
+      const Endpoint endpoint,
+      const uint32_t pos,
+      const uint32_t ring_size);
+};
+
+} // namespace katran

--- a/katran/lib/Vip.cpp
+++ b/katran/lib/Vip.cpp
@@ -24,18 +24,27 @@ bool compareEndpoints(const Endpoint& a, const Endpoint& b) {
   return a.hash < b.hash;
 };
 
-Vip::Vip(uint32_t vipNum, uint32_t vipFlags, uint32_t ringSize)
+Vip::Vip(
+    uint32_t vipNum,
+    uint32_t vipFlags,
+    uint32_t ringSize,
+    HashFunctions func)
     : vipNum_(vipNum),
       vipFlags_(vipFlags),
       chRingSize_(ringSize),
-      chRing_(ringSize, -1){};
+      chRing_(ringSize, -1) {
+  chash = CHHelpers::hashFunctionsFactory(func);
+};
 
-std::vector<RealPos> Vip::batchRealsUpdate(std::vector<UpdateReal>& ureals) {
+void Vip::setHashFunction(HashFunctions func) {
+  chash = CHHelpers::hashFunctionsFactory(func);
+}
+
+std::vector<RealPos> Vip::calculateHashRing(std::vector<Endpoint> endpoints) {
   std::vector<RealPos> delta;
   RealPos new_pos;
-  auto endpoints = getEndpoints(ureals);
   if (endpoints.size() != 0) {
-    auto new_ch_ring = CHHelpers::GenerateMaglevHash(endpoints, chRingSize_);
+    auto new_ch_ring = chash->generateHashRing(endpoints, chRingSize_);
 
     // compare new and old ch rings. send back only delta between em.
     for (int i = 0; i < chRingSize_; i++) {
@@ -48,7 +57,17 @@ std::vector<RealPos> Vip::batchRealsUpdate(std::vector<UpdateReal>& ureals) {
     }
   }
   return delta;
-};
+}
+
+std::vector<RealPos> Vip::batchRealsUpdate(std::vector<UpdateReal>& ureals) {
+  auto endpoints = getEndpoints(ureals);
+  return calculateHashRing(endpoints);
+}
+
+std::vector<RealPos> Vip::recalculateHashRing() {
+  auto reals = getRealsAndWeight();
+  return calculateHashRing(reals);
+}
 
 std::vector<RealPos> Vip::addReal(Endpoint real) {
   std::vector<UpdateReal> reals;
@@ -87,6 +106,7 @@ std::vector<Endpoint> Vip::getRealsAndWeight() {
     endpoint.hash = r.second.hash;
     endpoints[i++] = endpoint;
   }
+  std::sort(endpoints.begin(), endpoints.end(), compareEndpoints);
   return endpoints;
 }
 

--- a/katran/lib/Vip.cpp
+++ b/katran/lib/Vip.cpp
@@ -28,16 +28,16 @@ Vip::Vip(
     uint32_t vipNum,
     uint32_t vipFlags,
     uint32_t ringSize,
-    HashFunctions func)
+    HashFunction func)
     : vipNum_(vipNum),
       vipFlags_(vipFlags),
       chRingSize_(ringSize),
       chRing_(ringSize, -1) {
-  chash = CHHelpers::hashFunctionsFactory(func);
+  chash = CHFactory::make(func);
 };
 
-void Vip::setHashFunction(HashFunctions func) {
-  chash = CHHelpers::hashFunctionsFactory(func);
+void Vip::setHashFunction(HashFunction func) {
+  chash = CHFactory::make(func);
 }
 
 std::vector<RealPos> Vip::calculateHashRing(std::vector<Endpoint> endpoints) {

--- a/katran/lib/Vip.h
+++ b/katran/lib/Vip.h
@@ -63,7 +63,8 @@ class Vip {
   explicit Vip(
       uint32_t vipNum,
       uint32_t vipFlags = 0,
-      uint32_t ringSize = kDefaultChRingSize);
+      uint32_t ringSize = kDefaultChRingSize,
+      HashFunctions func = HashFunctions::Maglev);
 
   /**
    * getters
@@ -143,12 +144,31 @@ class Vip {
    */
   std::vector<RealPos> batchRealsUpdate(std::vector<UpdateReal>& ureals);
 
+  /**
+   * @param HashFunctions hash function to use for hash ring generation
+   *
+   * helper, which allows to change hashing functiong for hash ring generation
+   */
+  void setHashFunction(HashFunctions func);
+
+  /**
+   * @return vector<RealPos> delta (in terms of real's position) for ch ring
+   * 
+   * helper function which recalculates hash ring for the Vip
+   */
+  std::vector<RealPos> recalculateHashRing();
+
  private:
   /**
    * helper function which will modify reals_ and return vector of reals after
    * this modification
    */
   std::vector<Endpoint> getEndpoints(std::vector<UpdateReal>& ureals);
+
+  /**
+   * helper function to calculate hash ring and return delta
+   */
+  std::vector<RealPos> calculateHashRing(std::vector<Endpoint> endpoints);
 
   /**
    * number which uniquely identifies this vip
@@ -177,6 +197,11 @@ class Vip {
    * for delta computation (between old and new ch rings)
    */
   std::vector<int> chRing_;
+
+  /**
+   * hash function to generate hash ring
+   */
+  std::unique_ptr<ConsistentHash> chash;
 };
 
 } // namespace katran

--- a/katran/lib/Vip.h
+++ b/katran/lib/Vip.h
@@ -64,7 +64,7 @@ class Vip {
       uint32_t vipNum,
       uint32_t vipFlags = 0,
       uint32_t ringSize = kDefaultChRingSize,
-      HashFunctions func = HashFunctions::Maglev);
+      HashFunction func = HashFunction::Maglev);
 
   /**
    * getters
@@ -145,15 +145,15 @@ class Vip {
   std::vector<RealPos> batchRealsUpdate(std::vector<UpdateReal>& ureals);
 
   /**
-   * @param HashFunctions hash function to use for hash ring generation
+   * @param HashFunction hash function to use for hash ring generation
    *
    * helper, which allows to change hashing functiong for hash ring generation
    */
-  void setHashFunction(HashFunctions func);
+  void setHashFunction(HashFunction func);
 
   /**
    * @return vector<RealPos> delta (in terms of real's position) for ch ring
-   * 
+   *
    * helper function which recalculates hash ring for the Vip
    */
   std::vector<RealPos> recalculateHashRing();

--- a/katran/lib/maglev_integration_test.cpp
+++ b/katran/lib/maglev_integration_test.cpp
@@ -44,8 +44,7 @@ int main(int argc, char** argv) {
     }
     endpoints.push_back(endpoint);
   }
-  auto maglev_hashing =
-      katran::CHHelpers::hashFunctionsFactory(katran::HashFunctions::Maglev);
+  auto maglev_hashing = katran::CHFactory::make(katran::HashFunction::Maglev);
   auto ch1 = maglev_hashing->generateHashRing(endpoints);
   endpoints.pop_back();
   auto ch2 = maglev_hashing->generateHashRing(endpoints);

--- a/katran/lib/maglev_integration_test.cpp
+++ b/katran/lib/maglev_integration_test.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <vector>
 
-#include "CHHelpers.h"
+#include "katran/lib/CHHelpers.h"
 
 DEFINE_int64(weight, 100, "weights per real");
 DEFINE_int64(freq, 1, "how often real would have diff weight");
@@ -44,10 +44,11 @@ int main(int argc, char** argv) {
     }
     endpoints.push_back(endpoint);
   }
-
-  auto ch1 = katran::CHHelpers::GenerateMaglevHash(endpoints);
+  auto maglev_hashing =
+      katran::CHHelpers::hashFunctionsFactory(katran::HashFunctions::Maglev);
+  auto ch1 = maglev_hashing->generateHashRing(endpoints);
   endpoints.pop_back();
-  auto ch2 = katran::CHHelpers::GenerateMaglevHash(endpoints);
+  auto ch2 = maglev_hashing->generateHashRing(endpoints);
 
   for (int i = 0; i < ch1.size(); i++) {
     freq[ch1[i]]++;

--- a/katran/lib/tests/CHHelpersTest.cpp
+++ b/katran/lib/tests/CHHelpersTest.cpp
@@ -36,7 +36,7 @@ TEST(CHHelpersTest, testMaglevCHSameWeight) {
     endpoints.push_back(endpoint);
   }
 
-  auto maglev_hashing = CHHelpers::hashFunctionsFactory(HashFunctions::Maglev);
+  auto maglev_hashing = CHFactory::make(HashFunction::Maglev);
 
   auto maglev_ch = maglev_hashing->generateHashRing(endpoints);
 

--- a/katran/lib/tests/CHHelpersTest.cpp
+++ b/katran/lib/tests/CHHelpersTest.cpp
@@ -36,7 +36,9 @@ TEST(CHHelpersTest, testMaglevCHSameWeight) {
     endpoints.push_back(endpoint);
   }
 
-  auto maglev_ch = CHHelpers::GenerateMaglevHash(endpoints);
+  auto maglev_hashing = CHHelpers::hashFunctionsFactory(HashFunctions::Maglev);
+
+  auto maglev_ch = maglev_hashing->generateHashRing(endpoints);
 
   for (int i = 0; i < maglev_ch.size(); i++) {
     // test that we have changed all points inside ch ring

--- a/katran/lib/tests/VipTest.cpp
+++ b/katran/lib/tests/VipTest.cpp
@@ -107,6 +107,8 @@ TEST_F(VipTestF, testGetReals) {
   ASSERT_EQ(delta.size(), 65537);
   delta = vip1.batchRealsUpdate(reals);
   ASSERT_EQ(delta.size(), 0);
-};
+  delta = vip1.recalculateHashRing();
+  ASSERT_EQ(delta.size(), 0);
+}
 
 } // namespace katran


### PR DESCRIPTION
this patch would allow to hide implementation of how hash ring is calculated behind interface.
in future this would allow to easily plug in new/differnet ways to generate hash ring.

the issue with current implementation of maglev's hashing is that it requires for end user to have the sum of all weight to be equal to hash ring size. otherwise unequal load balancing wont work
(e.g. if you want to have real1 to receive 33% of traffic and real2 to 66% just specifying 
"real1 weight = 1" and "real2 weight =  2" wont work. instead you need to "real1 weight = ~20k , real2 weight ~40k" (w/ default hash ring size of 65537)).

changing existing implementation of maglev's hashing would break existing users of the library (e.g. after binary update during rollout different l4 load balancer wont be consistent)

proposed way for migration (and all helpers are added to do so) is to have logic which would works something like:
1. at time T (e.g. if now > T) , after deploying new binary everywhere, switch hashing to X for all vips in runtime (by changeHashFunctionForVip helper).  exisitng flow wont be affected (because of connection table). new flows would start to use new hashing alog.

modified maglev's hashing (which wont require sum to be the size of hash ring) is ongoing work and would be in separate PR


Tested-By:
- modified and existing UTs
- katran_tester   