### PR TITLE
make max_quic_reals configurable

### DIFF
--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -66,8 +66,10 @@
 #define MAX_DECAP_DST 6
 #endif
 
+#ifndef MAX_QUIC_REALS
 // use 24 bits in quic's connection id to store real's index
 #define MAX_QUIC_REALS 0x00fffffe // 2^24-1
+#endif
 
 #define CTL_MAP_SIZE 16
 


### PR DESCRIPTION
subj. allow to specify this constant during compilation. w/ recent changes the size of the map became 130mb+ which is not a small toll for users who do not even use quic

```
16: array  name quic_mapping  flags 0x0
        key 4B  value 4B  max_entries 16777214  memlock 134221824B
        btf_id 10
```