### PR TITLE
download libmnl from official site

### DIFF
--- a/build/fbcode_builder/manifests/libmnl
+++ b/build/fbcode_builder/manifests/libmnl
@@ -9,7 +9,7 @@ libmnl-static
 libmnl-dev
 
 [download]
-url = http://www.lg.ps.pl/mirrors/ftp.netfilter.org/libmnl/libmnl-1.0.4.tar.bz2
+url = http://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
 sha256 = 171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
 
 [build.os=linux]


### PR DESCRIPTION
downloading libmnl from www.lg.ps.pl mirror site often fails.