### PR TITLE
Fixes for building goclient with newest versions of go software

### DIFF
--- a/example_grpc/build_grpc_client.sh
+++ b/example_grpc/build_grpc_client.sh
@@ -20,20 +20,20 @@ set -xeo pipefail
 create_grpc_template () {
 rm -rf goclient/src/katranc/lb_katran
 mkdir -p goclient/src/katranc/lb_katran
-protoc -I protos/ protos/katran.proto --go_out=plugins=grpc:goclient/src/katranc/lb_katran
+protoc -I protos katran.proto --go_out=plugins=grpc:goclient/src/katranc/lb_katran
 }
 
 get_goclient_deps() {
     pushd .
     cd goclient/src/katranc/main
-    go get
+    GO111MODULE=auto go get
     popd
 }
 
 build_goclient() {
     pushd .
     cd goclient/src/katranc/main
-    go build
+    GO111MODULE=auto go build
     popd
 }
 

--- a/example_grpc/goclient/src/katranc/katranc/katranc.go
+++ b/example_grpc/goclient/src/katranc/katranc/katranc.go
@@ -18,7 +18,7 @@ package katranc
 
 import (
 	"fmt"
-	"katranc/lb_katran"
+	lb_katran "katranc/lb_katran"
 	"log"
 	"regexp"
 	"strconv"

--- a/example_grpc/protos/katran.proto
+++ b/example_grpc/protos/katran.proto
@@ -166,3 +166,4 @@ service KatranService {
   rpc getHealthcheckersDst (Empty) returns (hcMap);
 
 }
+option go_package = "./;protos";


### PR DESCRIPTION
Fixes go1.16 build errors:

1. protoc-gen-go: unable to determine Go import path for "katran.proto"
2. go: cannot find main module, but found .git/config in /path/to/katran
	to create a module there, run:
	cd ../../../../.. && go mod init
3.  ../katranc/katranc.go:21:2: imported and not used: "katranc/lb_katran" as protos
../katranc/katranc.go:70:9: undefined: lb_katran
../katranc/katranc.go:100:41: undefined: lb_katran
../katranc/katranc.go:128:58: undefined: lb_katran
../katranc/katranc.go:136:38: undefined: lb_katran
../katranc/katranc.go:187:6: undefined: lb_katran
../katranc/katranc.go:237:7: undefined: lb_katran
../katranc/katranc.go:270:38: undefined: lb_katran
../katranc/katranc.go:276:37: undefined: lb_katran
../katranc/katranc.go:283:45: undefined: lb_katran
../katranc/katranc.go:283:45: too many errors
