### PR TITLE
enable proper healthchecks testing

### DIFF
--- a/katran/lib/testing/BpfTester.cpp
+++ b/katran/lib/testing/BpfTester.cpp
@@ -134,7 +134,7 @@ void BpfTester::testClsFromFixture(
   for (auto& ctx : ctxs_in) {
     ctxs.push_back(&ctx);
   }
-  runBpfTesterFromFixtures(progFd, kTcCodes, {});
+  runBpfTesterFromFixtures(progFd, kTcCodes, ctxs, sizeof(struct __sk_buff));
 }
 
 bool BpfTester::runBpfTesterFromFixtures(

--- a/katran/lib/testing/KatranHCTestFixtures.h
+++ b/katran/lib/testing/KatranHCTestFixtures.h
@@ -42,8 +42,8 @@ namespace testing {
 
 const std::vector<struct __sk_buff> getInputCtxsForHcTest() {
     std::vector<struct __sk_buff> v;
-    for (int i = 0 ; i < 3 ; i++) {
-        struct __sk_buff skb;
+    for (int i = 0 ; i < 4 ; i++) {
+        struct __sk_buff skb = {};
         skb.mark = i;
         v.push_back(skb);
     }
@@ -59,15 +59,22 @@ const std::vector<std::pair<std::string, std::string>> inputHCTestFixtures = {
   },
   //2
   {
-    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
-    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    // Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/UDP(sport=31337, dport=80)/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
     "v4 packet. fwmark 1"
   },
+ 
   //3
+  {
+    //Ether(src="0x1", dst="0x2")/IP(src="192.168.1.1", dst="10.200.1.1")/TCP(sport=31337, dport=80, flags="A")/"katran test pkt"
+    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
+    "v4 packet. fwmark 2"
+  },
+  //4
   {
     //Ether(src="0x1", dst="0x2")/IPv6(src="fc00:2::1", dst="fc00:1::1")/TCP(sport=31337, dport=80,flags="A")/"katran test pkt"
     "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
-    "v4 packet. fwmkark 2"
+    "v6 packet. fwmark 3"
   },
 };
 
@@ -75,17 +82,22 @@ const std::vector<std::pair<std::string, std::string>> outputHCTestFixtures = {
   //1
   {
     "AgAAAAAAAQAAAAAACABFAAArAAEAAEARrU/AqAEBCsgBAXppAFAAF5fea2F0cmFuIHRlc3QgcGt0",
-    "TC_ACT_UNSPEC"
+    "TC_ACT_UNSPEC",
   },
   //2
   {
-    "AgAAAAAAAQAAAAAACABFAAA3AAEAAEAGrU7AqAEBCsgBAXppAFAAAAAAAAAAAFAQIAAn5AAAa2F0cmFuIHRlc3QgcGt0",
-    "TC_ACT_UNSPEC"
+    "AADerb6vAP/erb6vCABFAAA/AAAAAEAEWZYKAA0lCgAAAUUAACsAAQAAQBGtT8CoAQEKyAEBemkAUAAXl95rYXRyYW4gdGVzdCBwa3Q=",
+    "TC_ACT_REDIRECT"
   },
   //3
   {
-    "AgAAAAAAAQAAAAAAht1gAAAAACMGQPwAAAIAAAAAAAAAAAAAAAH8AAABAAAAAAAAAAAAAAABemkAUAAAAAAAAAAAUBAgAP1PAABrYXRyYW4gdGVzdCBwa3Q=",
-    "TC_ACT_UNSPEC"
+    "AADerb6vAP/erb6vCABFAABLAAAAAEAEWYkKAA0lCgAAAkUAADcAAQAAQAatTsCoAQEKyAEBemkAUAAAAAAAAAAAUBAgACfkAABrYXRyYW4gdGVzdCBwa3Q=",
+    "TC_ACT_REDIRECT"
+  },
+  //4
+  {
+    "AADerb6vAP/erb6vht1gAAAAAEspQPwAIwcAAAAAAAAAAAAAEzf8AAAAAAAAAAAAAAAAAAABYAAAAAAjBkD8AAACAAAAAAAAAAAAAAAB/AAAAQAAAAAAAAAAAAAAAXppAFAAAAAAAAAAAFAQIAD9TwAAa2F0cmFuIHRlc3QgcGt0",
+    "TC_ACT_REDIRECT"
   },
 };
 } // namespace testing


### PR DESCRIPTION
https://www.spinics.net/lists/netdev/msg620553.html landed long time ago and now widely available in vanilla kernels. we should enable proper healthchecking tests


Tests output:
```
I1122 23:35:29.210656 66233 BpfTester.cpp:224] Test: v4 packet. no fwmark                                         result: Passed
I1122 23:35:29.210664 66233 BpfTester.cpp:224] Test: v4 packet. fwmark 1                                          result: Passed
I1122 23:35:29.210671 66233 BpfTester.cpp:224] Test: v4 packet. fwmark 2                                          result: Passed
I1122 23:35:29.210678 66233 BpfTester.cpp:224] Test: v6 packet. fwmark 3                                          result: Passed
```

```
23:31:20.469250 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:31:20.469255 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:31:20.469260 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:31:20.469263 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto IPIP (4), length 63)
    10.0.13.37 > 10.0.0.1: IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 43)
    192.168.1.1.31337 > 10.200.1.1.80: [udp sum ok] UDP, length 15
23:31:20.469268 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:31:20.469270 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto IPIP (4), length 75)
    10.0.13.37 > 10.0.0.2: IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto TCP (6), length 55)
    192.168.1.1.31337 > 10.200.1.1.80: Flags [.], cksum 0x27e4 (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:31:20.469275 IP6 (hlim 64, next-header TCP (6) payload length: 35) fc00:2::1.31337 > fc00:1::1.80: Flags [.], cksum 0xfd4f (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
23:31:20.469277 IP6 (hlim 64, next-header IPv6 (41) payload length: 75) fc00:2307::1337 > fc00::1: IP6 (hlim 64, next-header TCP (6) payload length: 35) fc00:2::1.31337 > fc00:1::1.80: Flags [.], cksum 0xfd4f (correct), seq 0:15, ack 1, win 8192, length 15: HTTP
```