### PR TITLE
Changing openssl general dependency to debs dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ build() {
 }
 
 default_build() {
-    build --allow-system-packages --build-dir "$BUILD_DIR"
+    build --build-dir "$BUILD_DIR"
 }
 
 case $1 in

--- a/build/fbcode_builder/manifests/katran
+++ b/build/fbcode_builder/manifests/katran
@@ -27,7 +27,9 @@ libbpf
 libmnl
 zlib
 googletest
-openssl
+
+[debs]
+libssl-dev
 
 [shipit.pathmap]
 fbcode/katran/public_root = .


### PR DESCRIPTION
Summary:
Having the openssl general dependency generated problem with the default build of getdeps.py as it expected the `--allow-system-packages` flag, but this is disabled by default in the github-actions build as per D26743251 (https://github.com/facebookincubator/katran/commit/8f1438358322196f1c1c80aafcd27fd7cfb93149).

Found how to add the dependency of the development library for debian based distributions, so now it only requires in this case and our build doesn't need either the `--allow-system-packages` flag.

Differential Revision: D37636832

