### PR TITLE
migrating from folly::format to fmt::format

### DIFF
--- a/build/fbcode_builder/manifests/katran
+++ b/build/fbcode_builder/manifests/katran
@@ -27,6 +27,7 @@ libbpf
 libmnl
 zlib
 googletest
+fmt
 
 [debs]
 libssl-dev

--- a/build_katran.sh
+++ b/build_katran.sh
@@ -123,7 +123,8 @@ get_required_libs() {
             xz-devel \
             re2-devel \
             libatomic-static \
-            libsodium-static
+            libsodium-static \
+            fmt-devel
     else
         sudo apt-get install -y    \
             libgoogle-glog-dev     \
@@ -131,8 +132,9 @@ get_required_libs() {
             libelf-dev             \
             libmnl-dev             \
             liblzma-dev            \
-            libre2-dev
-        sudo apt-get install -y libsodium-dev
+            libre2-dev             \
+            libsodium-dev          \
+            libfmt-dev
     fi
 }
 

--- a/katran/lib/BaseBpfAdapter.cpp
+++ b/katran/lib/BaseBpfAdapter.cpp
@@ -17,9 +17,9 @@
 #include "BaseBpfAdapter.h"
 #include "Netlink.h"
 
+#include <fmt/core.h>
 #include <folly/CppAttributes.h>
 #include <folly/FileUtil.h>
-#include <folly/Format.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <glog/logging.h>
@@ -573,7 +573,7 @@ int BaseBpfAdapter::detachCgroupProgByPrefix(
   };
   auto progs_ids = getCgroupProgsIds(cgroup, type);
   if (progs_ids.empty()) {
-    LOG(ERROR) << folly::format(
+    LOG(ERROR) << fmt::format(
         "No bpf program found in cgroup {} of given type ", cgroup);
     return -1;
   }
@@ -590,7 +590,7 @@ int BaseBpfAdapter::detachCgroupProgByPrefix(
     auto bpfProgInfo = getBpfProgInfo(fd);
     folly::StringPiece progName = bpfProgInfo.name;
     if (progName.startsWith(progPrefix)) {
-      VLOG(2) << folly::format(
+      VLOG(2) << fmt::format(
           "Detaching bpf-prog {} with id {} by prefix match; given prefix: {}",
           progName,
           id,
@@ -651,12 +651,10 @@ int BaseBpfAdapter::getBpfProgInfo(int progFd, ::bpf_prog_info& info) {
 bpf_prog_info BaseBpfAdapter::getBpfProgInfo(int progFd) {
   ::bpf_prog_info info = {};
   if (getBpfProgInfo(progFd, info)) {
-    throw std::runtime_error(
-        folly::format(
-            "error while looking up info on bpf program: {}, error: {}",
-            progFd,
-            folly::errnoStr(errno))
-            .str());
+    throw std::runtime_error(fmt::format(
+        "error while looking up info on bpf program: {}, error: {}",
+        progFd,
+        folly::errnoStr(errno)));
   }
   return info;
 }

--- a/katran/lib/EventPipeCallback.cpp
+++ b/katran/lib/EventPipeCallback.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "katran/lib/EventPipeCallback.h"
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <folly/Utility.h>
 #include <stdint.h>
 #include "katran/lib/PcapStructs.h"
@@ -48,7 +48,7 @@ void EventPipeCallback::readBuffer(
           rec_hdr_sz + rec_hdr.incl_len);
       rcursor.skip(rec_hdr_sz + rec_hdr.incl_len);
     } else {
-      VLOG(2) << folly::format(
+      VLOG(2) << fmt::format(
           "incomplete pcap message, expecting {} bytes of data, got {}",
           rec_hdr.incl_len,
           rcursor.length());
@@ -60,7 +60,7 @@ void EventPipeCallback::readBuffer(
     if (enabled()) {
       auto subsmap = cb_subsmap_.rlock();
       for (auto& it : *subsmap) {
-        VLOG(4) << folly::sformat(
+        VLOG(4) << fmt::format(
             "sending event {} to client", toString(event_id_));
         it.second->sendEvent(msg);
       }
@@ -78,11 +78,11 @@ void EventPipeCallback::readBuffer(
 void EventPipeCallback::addClientSubscription(
     std::pair<ClientId, std::shared_ptr<ClientSubscriptionIf>>&& newSub) {
   ClientId cid = newSub.first;
-  VLOG(4) << __func__ << folly::sformat(" Adding client {}", cid);
+  VLOG(4) << __func__ << fmt::format(" Adding client {}", cid);
   auto cb_subsmap = cb_subsmap_.wlock();
   auto result = cb_subsmap->insert(std::move(newSub));
   if (!result.second) {
-    LOG(ERROR) << folly::format("duplicate client id: {}", cid);
+    LOG(ERROR) << fmt::format("duplicate client id: {}", cid);
   }
 }
 
@@ -90,7 +90,7 @@ void EventPipeCallback::removeClientSubscription(ClientId cid) {
   auto cb_subsmap = cb_subsmap_.wlock();
   size_t cnt = cb_subsmap->erase(cid);
   if (cnt != 1) {
-    LOG(ERROR) << folly::format(
+    LOG(ERROR) << fmt::format(
         "no client subscription associated with id: {}", cid);
   }
 }

--- a/katran/lib/EventPipeCallback.h
+++ b/katran/lib/EventPipeCallback.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <folly/Utility.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/async/AsyncPipe.h>
@@ -94,7 +94,7 @@ class EventPipeCallback : public folly::AsyncReader::ReadCallback {
   void readBuffer(std::unique_ptr<folly::IOBuf>&& buf) noexcept;
 
   void logerror(std::string msg) {
-    LOG(ERROR) << folly::format(
+    LOG(ERROR) << fmt::format(
         "EventPipeCallback({}): {}", toString(event_id_), msg);
   }
 

--- a/katran/lib/KatranEventReader.cpp
+++ b/katran/lib/KatranEventReader.cpp
@@ -15,7 +15,6 @@
  */
 #include "katran/lib/KatranEventReader.h"
 
-#include <folly/Format.h>
 #include <folly/Utility.h>
 #include <unistd.h>
 

--- a/katran/lib/KatranMonitor.cpp
+++ b/katran/lib/KatranMonitor.cpp
@@ -17,7 +17,6 @@
 #include "katran/lib/KatranMonitor.h"
 
 #include <folly/Conv.h>
-#include <folly/Format.h>
 #include <folly/Utility.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 

--- a/katran/lib/MacHelpers.cpp
+++ b/katran/lib/MacHelpers.cpp
@@ -18,7 +18,6 @@
 
 #include <glog/logging.h>
 
-#include <folly/Format.h>
 #include <folly/MacAddress.h>
 
 namespace katran {
@@ -50,7 +49,7 @@ std::string convertMacToString(std::vector<uint8_t> mac) {
   std::string mac_string;
   for (auto m : mac) {
     mac_part = m;
-    mac_part_string = folly::sformat("{0:02x}:", mac_part);
+    mac_part_string = fmt::format("{0:02x}:", mac_part);
     mac_string += mac_part_string;
   }
   return mac_string;

--- a/katran/lib/MonitoringServiceCore.cpp
+++ b/katran/lib/MonitoringServiceCore.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 #include "katran/lib/MonitoringServiceCore.h"
 #include <fcntl.h>
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <folly/Utility.h>
 
 namespace katran {
@@ -27,7 +27,7 @@ bool MonitoringServiceCore::initialize(std::shared_ptr<KatranMonitor> monitor) {
     int pipeFds[2];
     int rc = pipe2(pipeFds, O_NONBLOCK);
     if (rc != 0) {
-      LOG(ERROR) << folly::format(
+      LOG(ERROR) << fmt::format(
           "Creating pipes for event {} failed: {}", toString(eventId), rc);
       continue;
     }
@@ -193,7 +193,7 @@ void MonitoringServiceCore::cancelSubscription(ClientId cid) {
   CHECK(initialized_);
   auto clientAndEventIds = client_to_event_ids_.find(cid);
   if (clientAndEventIds == client_to_event_ids_.end()) {
-    LOG(ERROR) << folly::format("client {} has no associated events", cid);
+    LOG(ERROR) << fmt::format("client {} has no associated events", cid);
     // Best effor to clean up associated data
     for (auto& eventAndCallback : event_pipe_cbs_) {
       eventAndCallback.second->removeClientSubscription(cid);

--- a/katran/lib/PcapMsgMeta.cpp
+++ b/katran/lib/PcapMsgMeta.cpp
@@ -14,7 +14,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "katran/lib/PcapMsgMeta.h"
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <folly/Utility.h>
 
 namespace katran {
@@ -52,7 +52,7 @@ EventId PcapMsgMeta::getEventId() {
   try {
     return static_cast<EventId>(event_);
   } catch (const std::exception& e) {
-    LOG(ERROR) << folly::format("invalid event {}: {}", event_, e.what());
+    LOG(ERROR) << fmt::format("invalid event {}: {}", event_, e.what());
     return EventId::UNKNOWN;
   }
 }

--- a/katran/lib/testing/BpfTester.cpp
+++ b/katran/lib/testing/BpfTester.cpp
@@ -16,11 +16,11 @@
 
 #include "katran/lib/testing/BpfTester.h"
 
-#include <iostream>
-
-#include <folly/Format.h>
+#include <fmt/core.h>
+#include <folly/String.h>
 #include <folly/io/IOBuf.h>
 #include <glog/logging.h>
+#include <iostream>
 
 namespace katran {
 
@@ -253,7 +253,7 @@ bool BpfTester::runBpfTesterFromFixtures(
     overallSuccess = overallSuccess && iterationSuccess;
 
     VLOG(2) << "pckt #" << pckt_num;
-    LOG(INFO) << folly::format(
+    LOG(INFO) << fmt::format(
         "Test: {:60} result: {}", config_.testData[i].description, test_result);
     ++pckt_num;
   }
@@ -301,7 +301,7 @@ void BpfTester::testPerfFromFixture(uint32_t repeat, const int position) {
       duration = 1;
     }
     auto pps = kNanosecInSec / duration;
-    LOG(INFO) << folly::format(
+    LOG(INFO) << fmt::format(
         "Test: {:60} duration: {:10} ns/pckt or {} pps",
         config_.testData[i].description,
         duration,

--- a/katran/lib/tests/KatranLbTest.cpp
+++ b/katran/lib/tests/KatranLbTest.cpp
@@ -14,7 +14,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include "katran/lib/KatranLb.h"
@@ -83,12 +83,12 @@ class KatranLbTest : public ::testing::Test {
       for (int j = 0; j < 256; j++) {
         k = (i * 256 + j);
         if (k < kMaxNumOfReals) {
-          real1.address = folly::sformat("10.0.{}.{}", i, j);
+          real1.address = fmt::format("10.0.{}.{}", i, j);
           newReals1.push_back(real1);
           qreal1.address = real1.address;
           qreal1.id = k;
           qReals1.push_back(qreal1);
-          real2.address = folly::sformat("10.1.{}.{}", i, j);
+          real2.address = fmt::format("10.1.{}.{}", i, j);
           newReals2.push_back(real2);
           qreal2.address = real2.address;
           qreal2.id = k;
@@ -394,7 +394,7 @@ TEST_F(KatranLbTest, addValidSrcRoutingRuleV6) {
 TEST_F(KatranLbTest, addMaxSrcRules) {
   std::vector<std::string> srcs;
   for (int i = 0; i < 20; i++) {
-    auto prefix = folly::sformat("10.0.{}.0/24", i);
+    auto prefix = fmt::format("10.0.{}.0/24", i);
     srcs.push_back(prefix);
   }
   auto res = lb->addSrcRoutingRule(srcs, "fc00::1");
@@ -412,7 +412,7 @@ TEST_F(KatranLbTest, addMaxSrcRules) {
 TEST_F(KatranLbTest, delSrcRules) {
   std::vector<std::string> srcs;
   for (int i = 0; i < 10; i++) {
-    auto prefix = folly::sformat("10.0.{}.0/24", i);
+    auto prefix = fmt::format("10.0.{}.0/24", i);
     srcs.push_back(prefix);
   }
   ASSERT_EQ(lb->addSrcRoutingRule(srcs, "fc00::1"), 0);
@@ -424,7 +424,7 @@ TEST_F(KatranLbTest, delSrcRules) {
 TEST_F(KatranLbTest, clearSrcRules) {
   std::vector<std::string> srcs;
   for (int i = 0; i < 10; i++) {
-    auto prefix = folly::sformat("10.0.{}.0/24", i);
+    auto prefix = fmt::format("10.0.{}.0/24", i);
     srcs.push_back(prefix);
   }
   ASSERT_EQ(lb->addSrcRoutingRule(srcs, "fc00::1"), 0);
@@ -436,7 +436,7 @@ TEST_F(KatranLbTest, clearSrcRules) {
 TEST_F(KatranLbTest, addFewInvalidNets) {
   std::vector<std::string> srcs;
   for (int i = 0; i < 7; i++) {
-    auto prefix = folly::sformat("10.0.{}.0/24", i);
+    auto prefix = fmt::format("10.0.{}.0/24", i);
     srcs.push_back(prefix);
   }
   srcs.push_back("aaa");

--- a/tools/xdpdump/XdpDump.cpp
+++ b/tools/xdpdump/XdpDump.cpp
@@ -23,7 +23,7 @@
 
 #include <bcc/libbpf.h>
 #include <bcc/table_storage.h>
-#include <folly/Format.h>
+#include <fmt/core.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>
 
@@ -122,45 +122,45 @@ void XdpDump::compile() {
 void XdpDump::prepareCflags() {
   if (filter_.ipv6) {
     if ((filter_.flags & kSrcSet) > 0) {
-      cflags_.push_back(folly::sformat("-DSRCV6_0={}", filter_.srcv6[0]));
-      cflags_.push_back(folly::sformat("-DSRCV6_1={}", filter_.srcv6[1]));
-      cflags_.push_back(folly::sformat("-DSRCV6_2={}", filter_.srcv6[2]));
-      cflags_.push_back(folly::sformat("-DSRCV6_3={}", filter_.srcv6[3]));
+      cflags_.push_back(fmt::format("-DSRCV6_0={}", filter_.srcv6[0]));
+      cflags_.push_back(fmt::format("-DSRCV6_1={}", filter_.srcv6[1]));
+      cflags_.push_back(fmt::format("-DSRCV6_2={}", filter_.srcv6[2]));
+      cflags_.push_back(fmt::format("-DSRCV6_3={}", filter_.srcv6[3]));
     }
     if ((filter_.flags & kDstSet) > 0) {
-      cflags_.push_back(folly::sformat("-DDSTV6_0={}", filter_.dstv6[0]));
-      cflags_.push_back(folly::sformat("-DDSTV6_1={}", filter_.dstv6[1]));
-      cflags_.push_back(folly::sformat("-DDSTV6_2={}", filter_.dstv6[2]));
-      cflags_.push_back(folly::sformat("-DDSTV6_3={}", filter_.dstv6[3]));
+      cflags_.push_back(fmt::format("-DDSTV6_0={}", filter_.dstv6[0]));
+      cflags_.push_back(fmt::format("-DDSTV6_1={}", filter_.dstv6[1]));
+      cflags_.push_back(fmt::format("-DDSTV6_2={}", filter_.dstv6[2]));
+      cflags_.push_back(fmt::format("-DDSTV6_3={}", filter_.dstv6[3]));
     }
   } else {
     if ((filter_.flags & kSrcSet) > 0) {
-      cflags_.push_back(folly::sformat("-DSRCV4={}", filter_.src));
+      cflags_.push_back(fmt::format("-DSRCV4={}", filter_.src));
     }
     if ((filter_.flags & kDstSet) > 0) {
-      cflags_.push_back(folly::sformat("-DDSTV4={}", filter_.dst));
+      cflags_.push_back(fmt::format("-DDSTV4={}", filter_.dst));
     }
   }
   if ((filter_.flags & kSportSet) > 0) {
-    cflags_.push_back(folly::sformat("-DSPORT={}", htons(filter_.sport)));
+    cflags_.push_back(fmt::format("-DSPORT={}", htons(filter_.sport)));
   }
   if ((filter_.flags & kDportSet) > 0) {
-    cflags_.push_back(folly::sformat("-DDPORT={}", htons(filter_.dport)));
+    cflags_.push_back(fmt::format("-DDPORT={}", htons(filter_.dport)));
   }
   if ((filter_.flags & kProtoSet) > 0) {
-    cflags_.push_back(folly::sformat("-DPROTO={}", filter_.proto));
+    cflags_.push_back(fmt::format("-DPROTO={}", filter_.proto));
   }
   if (filter_.offset_len > 0) {
-    cflags_.push_back(folly::sformat("-DOFFSET={}", filter_.offset));
-    cflags_.push_back(folly::sformat("-DO_LEN={}", filter_.offset_len));
-    cflags_.push_back(folly::sformat("-DO_PATTERN={}", filter_.pattern));
+    cflags_.push_back(fmt::format("-DOFFSET={}", filter_.offset));
+    cflags_.push_back(fmt::format("-DO_LEN={}", filter_.offset_len));
+    cflags_.push_back(fmt::format("-DO_PATTERN={}", filter_.pattern));
   }
   if (filter_.count > 0) {
     // not yet used
-    cflags_.push_back(folly::sformat("-DCOUNT={}", filter_.count));
+    cflags_.push_back(fmt::format("-DCOUNT={}", filter_.count));
   }
   if (filter_.cpu >= 0) {
-    cflags_.push_back(folly::sformat("-DCPU_NUMBER={}", filter_.cpu));
+    cflags_.push_back(fmt::format("-DCPU_NUMBER={}", filter_.cpu));
   }
 }
 


### PR DESCRIPTION
Summary: While working in fixing the build a message of folly::format being deprecated continously appeared, so doing the migration to remove the noise.

Differential Revision: D39898942

