### PR TITLE
Fixing build in ubuntu 22

### DIFF
--- a/build_katran.sh
+++ b/build_katran.sh
@@ -516,7 +516,7 @@ get_grpc() {
     echo -e "${COLOR_GREEN}[ INFO ] Cloning grpc repo ${COLOR_OFF}"
     # pin specific release of grpc to avoid build failures
     # with new changes in grpc/absl
-    git clone  --depth 1 https://github.com/grpc/grpc --branch v1.27.1
+    git clone  --depth 1 https://github.com/grpc/grpc --branch v1.49.1
     # this is to deal with a nested dir
     cd grpc
     git submodule update --init

--- a/example_grpc/CMakeLists.txt
+++ b/example_grpc/CMakeLists.txt
@@ -4,25 +4,12 @@ set (CMAKE_CXX_STANDARD 14)
 
 find_library(PROTOBUF libprotobuf.a protobuf)
 set(GRPC_BUILD_PATH "${CMAKE_PREFIX_PATH}/grpc/_build")
-set(GRPC_LIBRARIES_PATH "${GRPC_BUILD_PATH}")
-set(CARES_LIBRARIES_PATH "${GRPC_LIBRARIES_PATH}/third_party/cares/cares/lib")
-set(ABSL_LIBRARIES_PATH "${GRPC_LIBRARIES_PATH}/third_party/abseil-cpp/absl")
 
-find_library(ADDR_SORT libaddress_sorting.a address_sorting PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(GPR libgpr.a gpr PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(GRPC libgrpc.a grpc PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(GRPC++ libgrpc++.a grpc++ PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(CARES libcares.a cares PATHS ${CARES_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(GRPC_UNSECURE libgrpc_unsecure.a grpc_unsecure PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
-find_library(UPB libupb.a grpc PATHS ${GRPC_LIBRARIES_PATH} NO_DEFAULT_PATH)
 find_library(LIBIBERTY libiberty.a iberty)
 find_library(DL dl)
 find_library(EVENT libevent.a event)
-find_library(ABSL_BASE libabsl_base.a absl_base "${ABSL_LIBRARIES_PATH}/base" NO_DEFAULT_PATH)
-find_library(ABSL_BASE_THROW libabsl_throw_delegate.a absl_throw_delegate "${ABSL_LIBRARIES_PATH}/base" NO_DEFAULT_PATH)
-find_library(ABSL_STRINGS libabsl_strings.a absl_strings "${ABSL_LIBRARIES_PATH}/strings" NO_DEFAULT_PATH)
-find_library(ABSL_BAD_OPTIONAL libabsl_bad_optional_access.a absl_bad_optional_access "${ABSL_LIBRARIES_PATH}/types" NO_DEFAULT_PATH)
 find_package(Protobuf REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
 
 set(PROTO_PATH "${CMAKE_SOURCE_DIR}/example_grpc/protos")
 set(KATRAN_PROTO "${PROTO_PATH}/katran.proto")
@@ -75,11 +62,8 @@ add_library(grpc_signal_handler
 target_link_libraries(grpc_signal_handler
     "Folly::folly"
     "${DL}"
-    "${EVENT}"
-    "${GRPC++}"
-    "${GPR}"
-    "${ADDR_SORT}"
-    "${CARES}"
+    gRPC::grpc++
+    gRPC::gpr
 )
 
 add_executable(katran_server_grpc katran_server.cpp)
@@ -87,10 +71,6 @@ target_link_libraries(katran_server_grpc
   "-Wl,--start-group"
   "${LIBUNWIND}"
   "${PROTOBUF}"
-  "${GRPC++}"
-  "${GPR}"
-  "${ADDR_SORT}"
-  "${CARES}"
   "Folly::folly"
   "glog::glog"
   "${GFLAGS}"
@@ -98,14 +78,18 @@ target_link_libraries(katran_server_grpc
   "${LIBDC}"
   "${DL}"
   "${LIBIBERTY}"
-  "${GRPC_UNSECURE}"
   "${LIBZ}"
-  "${UPB}"
-  "${ABSL_BASE_THROW}"
-  "${ABSL_STRINGS}"
-  "${ABSL_BAD_OPTIONAL}"
   katran_service_handler
   grpc_signal_handler
+  gRPC::grpc++
+  gRPC::gpr
+  gRPC::grpc_unsecure
+  # absl is from grpc
+  absl::base
+  absl::cord
+  absl::node_hash_set
+  absl::random_random
+  absl::statusor
   "-Wl,--end-group"
 )
 


### PR DESCRIPTION
Summary:
The main problem of why katran couldn't be build in ubuntu 22 is because the gRPC 1.27 dependencies had different problems with what ubuntu 22 has by default.

Updating to gRPC 1.49 to fix this problem at the moment, but doing this update changed the manual dependencies gRPC had for abseil. So updated that in example_grpc, and instead of doing the lookup into the folders, I think is better to see how gRPC handles its dependencies with the `find_package(gRPC CONFIG REQUIRED)`, and just link them directly, as this is easier for future changes.

Removed some other dependencies that are dependency for gRPC, but are not required for our build.

Differential Revision: D39949618

