### PR TITLE
zlib-1.2.12 not found, replace with zlib-1.2.13

### DIFF
--- a/build/fbcode_builder/manifests/zlib
+++ b/build/fbcode_builder/manifests/zlib
@@ -12,8 +12,8 @@ zlib-devel
 zlib-static
 
 [download]
-url = http://zlib.net/zlib-1.2.12.tar.gz
-sha256 = 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+url = http://zlib.net/zlib-1.2.13.tar.gz
+sha256 = b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
 
 [build]
 builder = cmake

--- a/build/fbcode_builder/patches/zlib_dont_build_more_than_needed.patch
+++ b/build/fbcode_builder/patches/zlib_dont_build_more_than_needed.patch
@@ -1,16 +1,16 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -183,8 +183,7 @@
+@@ -147,8 +147,7 @@
      set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
  endif(MINGW)
 
--add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
--add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 +add_library(zlib ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
  set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
  set_target_properties(zlib PROPERTIES SOVERSION 1)
 
-@@ -201,7 +200,7 @@
+@@ -165,7 +164,7 @@
 
  if(UNIX)
      # On unix-like platforms the library is almost always called libz
@@ -19,7 +19,7 @@
     if(NOT APPLE)
       set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
     endif()
-@@ -211,7 +210,7 @@
+@@ -175,7 +174,7 @@
  endif()
 
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )


### PR DESCRIPTION
404 Not found for url http://zlib.net/zlib-1.2.12.tar.gz. 
In [zlib ](http://zlib.net/) official site, it says that "Due to the first bug fix, any installations of 1.2.12 or earlier should be replaced with 1.2.13" .
