### PR TITLE
[lib]: moving defaults to prev values

### DIFF
--- a/katran/decap/bpf/decap_kern.c
+++ b/katran/decap/bpf/decap_kern.c
@@ -233,7 +233,6 @@ __attribute__((__always_inline__)) static inline int process_packet(
     return XDP_PASS;
   }
 
-  // data_stats->total += 1;
   if (protocol == IPPROTO_IPIP || protocol == IPPROTO_IPV6) {
 #ifdef DECAP_STRICT_DESTINATION
     action = check_decap_dst(&pckt, is_ipv6);

--- a/katran/lib/KatranLbStructs.h
+++ b/katran/lib/KatranLbStructs.h
@@ -29,7 +29,7 @@ constexpr uint32_t kDefaultPriority = 2307;
 
 namespace {
 constexpr uint32_t kDefaultKatranPos = 2;
-constexpr uint32_t kDefaultMaxVips = 2048;
+constexpr uint32_t kDefaultMaxVips = 512;
 constexpr uint32_t kDefaultMaxReals = 4096;
 constexpr uint32_t kLbDefaultChRingSize = 65537;
 constexpr uint32_t kDefaultMaxLpmSrcSize = 3000000;


### PR DESCRIPTION
https://github.com/facebookincubator/katran/commit/95e67746b4ba3c0b647ac62a7cf40079344841bf changed default max vips to 2048 (no idea why). The issue is that this value must be in sync with https://github.com/facebookincubator/katran/blob/main/katran/lib/bpf/balancer_consts.h#L51
otherwise you will have out of bound access in the userspace (because actual default build of bpf prog would have array size of 512 for vips while userspace thinks it is 2048).
There is no reason to change defaults (you can pass w/e you want during KatranLB consruction; however changing them would hurt library users (e.g. if you going to change bpf to use 2048 as well - you will change default hashing seed and users would have broken balancers if they would try to update them in prod - because 2 instances would have different output of hash function and consistency of the caching would be broken)


Also while i'm here - removing commented line. 