### PR TITLE
Fixing missing "/" in example_grpc/build_grpc_client.sh

### DIFF
--- a/example_grpc/build_grpc_client.sh
+++ b/example_grpc/build_grpc_client.sh
@@ -62,7 +62,7 @@ cp $(go env GOPATH)/bin/protoc-gen-go-grpc $(go env GOPATH)/bin/protoc-gen-go_gr
 """
 # fail hard if go or protoc is not installed
 go version 1>/dev/null
-protoc --version 1>dev/null
+protoc --version 1>/dev/null
 # adding export paths
 export GOPATH=$(pwd)/goclient
 create_grpc_template


### PR DESCRIPTION
There is a missing "/" in [example_grpc/build_grpc_client.sh](https://github.com/facebookincubator/katran/blob/main/example_grpc/build_grpc_client.sh#L65)L65, which will lead to a building failure.