### PR TITLE
fix build against libstdc++ 12

### DIFF
--- a/katran/lib/BpfLoader.cpp
+++ b/katran/lib/BpfLoader.cpp
@@ -17,6 +17,8 @@
 
 #include "BpfLoader.h"
 
+#include <array>
+
 #include <glog/logging.h>
 
 namespace katran {


### PR DESCRIPTION
While attempting to compile katran on Debian Bullseye and Bookworm I've realized that it compiled as expected on Bullseye with clang-13 but failed on Bookworm with the same compiler issuing the following error:
```
/tmp/fbcode_builder_getdeps-ZrootZkatranZbuildZfbcode_builder-root/repos/github.com-facebookincubator-katran.git/katran/lib/BpfLoader.cpp:46:25:
 error: implicit instantiation of undefined template 'std::array<char, 128>'
 std::array<char, 128> buf{};
```
Debugging the issue with clang++ -H I've noticed that BpfLoader.h:21: #include <unordered_map>
implicitly includes array when using libstdc++ 10:
```
.. /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/unordered_map
... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/hashtable.h
.... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/hashtable_policy.h
..... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/tuple
...... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/array
...... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/uses_allocator.h
...... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h
..... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/limits
... /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unordered_map.h
```
but this doesn't happen with libstdc++ 12:
```
.. /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/unordered_map
... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/hashtable.h
.... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/hashtable_policy.h
..... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/tuple
...... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/uses_allocator.h
.... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/enable_special_members.h
... /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unordered_map.h
```

Adding a explicit `#include <array>`  fixes the error