### PR TITLE
fix map name

### DIFF
--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -2060,7 +2060,7 @@ lb_quic_packets_stats KatranLb::getLbQuicPacketsStats() {
   if (!config_.testing) {
     int position = 0;
     auto res = bpfAdapter_->bpfMapLookupElement(
-        bpfAdapter_->getMapFdByName("quic_packets_stats_map"),
+        bpfAdapter_->getMapFdByName("quic_stats_map"),
         &position,
         stats);
     if (!res) {
@@ -2112,7 +2112,7 @@ lb_tpr_packets_stats KatranLb::getTcpServerIdRoutingStats() {
   if (!config_.testing) {
     int position = 0;
     auto res = bpfAdapter_->bpfMapLookupElement(
-        bpfAdapter_->getMapFdByName("tpr_packets_stats_map"), &position, stats);
+        bpfAdapter_->getMapFdByName("tpr_stats_map"), &position, stats);
     if (!res) {
       for (auto& stat : stats) {
         sum_stat.ch_routed += stat.ch_routed;
@@ -2595,7 +2595,7 @@ lb_stats KatranLb::getSidRoutingStatsForVip(const VipKey& vip) {
     return lb_stats{};
   }
   auto vipNum = vip_iter->second.getVipNum();
-  return getLbStats(vipNum, "server_id_routing_stats");
+  return getLbStats(vipNum, "server_id_stats");
 }
 
 } // namespace katran

--- a/katran/lib/KatranLb.cpp
+++ b/katran/lib/KatranLb.cpp
@@ -244,7 +244,7 @@ void KatranLb::initialSanityChecking(bool flowDebug, bool globalLru) {
     maps.push_back("lru_mapping");
     maps.push_back("server_id_map");
     maps.push_back("lru_miss_stats");
-    maps.push_back("lru_miss_stats_vip");
+    maps.push_back("vip_miss_stats");
 
     if (flowDebug) {
       maps.push_back(kFlowDebugParentMapName.data());
@@ -827,7 +827,7 @@ void KatranLb::loadBpfProgs() {
   memset(&vip_def, 0, sizeof(vip_definition));
   uint32_t key = 0;
   res = bpfAdapter_->bpfUpdateMap(
-      bpfAdapter_->getMapFdByName("lru_miss_stats_vip"), &key, &vip_def);
+      bpfAdapter_->getMapFdByName("vip_miss_stats"), &key, &vip_def);
   if (res) {
     LOG(ERROR) << "can't update lru miss stat vip, error: "
                << folly::errnoStr(errno);
@@ -1950,7 +1950,7 @@ bool KatranLb::logVipLruMissStats(VipKey& vip) {
   vip_definition vip_def = vipKeyToVipDefinition(vip);
   uint32_t vip_key = 0;
   auto res = bpfAdapter_->bpfUpdateMap(
-      bpfAdapter_->getMapFdByName("lru_miss_stats_vip"), &vip_key, &vip_def);
+      bpfAdapter_->getMapFdByName("vip_miss_stats"), &vip_key, &vip_def);
   if (res != 0) {
     LOG(ERROR) << "can't update lru miss stat vip, error: "
                << folly::errnoStr(errno);

--- a/katran/lib/bpf/balancer.bpf.c
+++ b/katran/lib/bpf/balancer.bpf.c
@@ -573,7 +573,7 @@ check_and_update_real_index_in_lru(
 __attribute__((__always_inline__)) static inline void
 incr_server_id_routing_stats(__u32 vip_num, bool newConn, bool misMatchInLRU) {
   struct lb_stats* per_vip_stats =
-      bpf_map_lookup_elem(&server_id_routing_stats, &vip_num);
+      bpf_map_lookup_elem(&server_id_stats, &vip_num);
   if (!per_vip_stats) {
     return;
   }
@@ -774,7 +774,7 @@ process_packet(struct xdp_md* xdp, __u64 off, bool is_ipv6) {
     } else {
       __u32 quic_packets_stats_key = 0;
       struct lb_quic_packets_stats* quic_packets_stats =
-          bpf_map_lookup_elem(&quic_packets_stats_map, &quic_packets_stats_key);
+          bpf_map_lookup_elem(&quic_stats_map, &quic_packets_stats_key);
       if (!quic_packets_stats) {
         return XDP_DROP;
       }
@@ -843,7 +843,7 @@ process_packet(struct xdp_md* xdp, __u64 off, bool is_ipv6) {
     if (pckt.flow.proto == IPPROTO_TCP) {
       __u32 tpr_packets_stats_key = 0;
       struct lb_tpr_packets_stats* tpr_packets_stats =
-          bpf_map_lookup_elem(&tpr_packets_stats_map, &tpr_packets_stats_key);
+          bpf_map_lookup_elem(&tpr_stats_map, &tpr_packets_stats_key);
       if (!tpr_packets_stats) {
         return XDP_DROP;
       }

--- a/katran/lib/bpf/balancer.bpf.c
+++ b/katran/lib/bpf/balancer.bpf.c
@@ -516,10 +516,10 @@ __attribute__((__always_inline__)) static inline int update_vip_lru_miss_stats(
     struct packet_description* pckt,
     struct vip_meta* vip_info,
     bool is_ipv6) {
-  // track the lru miss counter of vip in lru_miss_stats_vip
-  __u32 lru_miss_stats_vip_key = 0;
+  // track the lru miss counter of vip in vip_miss_stats
+  __u32 vip_miss_stats_key = 0;
   struct vip_definition* lru_miss_stat_vip =
-      bpf_map_lookup_elem(&lru_miss_stats_vip, &lru_miss_stats_vip_key);
+      bpf_map_lookup_elem(&vip_miss_stats, &vip_miss_stats_key);
   if (!lru_miss_stat_vip) {
     return XDP_DROP;
   }
@@ -913,7 +913,7 @@ process_packet(struct xdp_md* xdp, __u64 off, bool is_ipv6) {
         return XDP_DROP;
       }
 
-      // track the lru miss counter of vip in lru_miss_stats_vip
+      // track the lru miss counter of vip in vip_miss_stats
       if (update_vip_lru_miss_stats(&vip, &pckt, vip_info, is_ipv6) >= 0) {
         return XDP_DROP;
       }

--- a/katran/lib/bpf/balancer_maps.h
+++ b/katran/lib/bpf/balancer_maps.h
@@ -105,7 +105,7 @@ struct {
   __type(value, struct vip_definition);
   __uint(max_entries, 1);
   __uint(map_flags, NO_FLAGS);
-} lru_miss_stats_vip SEC(".maps");
+} vip_miss_stats SEC(".maps");
 
 // map w/ per vip statistics
 struct {

--- a/katran/lib/bpf/balancer_maps.h
+++ b/katran/lib/bpf/balancer_maps.h
@@ -123,7 +123,7 @@ struct {
   __type(value, struct lb_quic_packets_stats);
   __uint(max_entries, QUIC_STATS_MAP_SIZE);
   __uint(map_flags, NO_FLAGS);
-} quic_packets_stats_map SEC(".maps");
+} quic_stats_map SEC(".maps");
 
 // map for server-id to real's id mapping. The ids can be embedded in header of
 // QUIC or TCP (if enabled) packets for routing of packets for existing flows
@@ -199,7 +199,7 @@ struct {
   __type(value, struct lb_tpr_packets_stats);
   __uint(max_entries, TPR_STATS_MAP_SIZE);
   __uint(map_flags, NO_FLAGS);
-} tpr_packets_stats_map SEC(".maps");
+} tpr_stats_map SEC(".maps");
 
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -207,6 +207,6 @@ struct {
   __type(value, struct lb_stats);
   __uint(max_entries, MAX_VIPS);
   __uint(map_flags, NO_FLAGS);
-} server_id_routing_stats SEC(".maps");
+} server_id_stats SEC(".maps");
 
 #endif // of _BALANCER_MAPS


### PR DESCRIPTION
to be able to restart katran's bpf code in runtime (e.g. to load bpf code w/ introspection enabled w/o restarting binary) all maps must have name w/ size less than 15 chars (because kernel truncates map name to 15 chars; https://github.com/facebookincubator/katran/blob/main/katran/lib/BpfLoader.cpp#L104 ) making lru_miss_stats smaller so it would not block this logic