### PR TITLE
fix handling large packets and sending icmp-too-big fragmentation bug

### DIFF
--- a/katran/lib/bpf/handle_icmp.h
+++ b/katran/lib/bpf/handle_icmp.h
@@ -151,6 +151,7 @@ __attribute__((__always_inline__)) static inline int send_icmp4_too_big(
   iph->ttl = DEFAULT_TTL;
   iph->daddr = orig_iph->saddr;
   iph->saddr = orig_iph->daddr;
+  iph->frag_off = 0;
   iph->version = 4;
   iph->ihl = 5;
   iph->protocol = IPPROTO_ICMP;


### PR DESCRIPTION
bpf(icmp-too-big): This commit fixes a bug that katran cannot deal with large packets.
Katran should generate `ICMP_TOO_BIG` packet ('destination unreachable') for this situation but randomly packets dropped from processing in NIC due to checksum issue.
So, we need to generate an IP header with `frag_off = 0` option to fix bytes replacements and fragmentation affects.