### PR TITLE
docs: update README.md with render-able status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/badge/Support-Ukraine-FFD500?style=flat&labelColor=005BBB" alt="Support Ukraine" />
   </a>
   <a href="https://github.com/facebookincubator/katran/actions?workflow=CI">
-    <img src="https://github.com/facebookincubator/katran/workflows/CI/badge.svg" alt="CI Status" />
+    <img src="https://github.com/facebookincubator/katran/actions/workflows/getdeps_linux.yml/badge.svg" alt="CI Status" />
   </a>
 </p>
 


### PR DESCRIPTION
Ahoy all!

Came across this repo while reading up on some of the sweet work happening in the eBPF space.
The CI status badge in the README wasn't rendering as expected, so small PR to address that. 

Before:
![image](https://github.com/facebookincubator/katran/assets/18715356/b1ee3f75-efaf-4cee-9a5e-06d2f0eb0814)

After:
![image](https://github.com/facebookincubator/katran/assets/18715356/d1ccc1ad-69c5-42ca-8cb1-62baa418b7bb)

Cheers!