### PR TITLE
[katran][oss] Fixing build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.9)
+cmake_minimum_required (VERSION 3.9 FATAL_ERROR)
 
 project(
   katran
@@ -19,12 +19,12 @@ set(KATRAN_FBCODE_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(KATRAN_INCLUDE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
+
 # for clang's compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-set(CMAKE_CXX_COMPILER_ID "Clang")
-
-set(CMAKE_CXX_STANDARD 14)
 
 # Dependencies
 find_package(fmt CONFIG REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (katranserver-proj)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 # thrift cmake macro
 find_program(THRIFT1 thrift1)

--- a/example_grpc/CMakeLists.txt
+++ b/example_grpc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(katran_grpc)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 find_library(PROTOBUF libprotobuf.a protobuf)
 set(GRPC_BUILD_PATH "${CMAKE_PREFIX_PATH}/grpc/_build")

--- a/tools/xdpdump/CMakeLists.txt
+++ b/tools/xdpdump/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(xdpdump)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 find_library(LIBBCC bcc)
 find_library(DL dl)


### PR DESCRIPTION
After diving in all the build system I found that the first error mentioned in https://github.com/facebookincubator/katran/issues/219 and https://github.com/facebookincubator/katran/issues/220

```
1597 | static_assert(formattable_char, "Mixing character types is disallowed.");
```

Was basically happening while compiling folly, after compiling it by itself I noticed this didn't happened, so I found that there was an issue with the fmt dependencies, removing the one that was downloaded by katran

The issue mentioned in: https://github.com/facebookincubator/katran/issues/221

Was because katran was configured to use C++14 by default, and some of the libraries of folly require C++17, updated our requirements.


TEST Output:

```
Test project /home/ubuntu/ivanmorett/katran/_build/build/katran/lib/tests
      Start  1: IpHelpersTests.testV4ParsingBe
 1/56 Test  #1: IpHelpersTests.testV4ParsingBe .......................   Passed    0.01 sec
      Start  2: IpHelpersTests.testV4ParsingInt
 2/56 Test  #2: IpHelpersTests.testV4ParsingInt ......................   Passed    0.01 sec
      Start  3: IpHelpersTests.testV6ParsingBe
 3/56 Test  #3: IpHelpersTests.testV6ParsingBe .......................   Passed    0.01 sec
      Start  4: IpHelpersTests.testV6ParsingInt
 4/56 Test  #4: IpHelpersTests.testV6ParsingInt ......................   Passed    0.01 sec
      Start  5: IpHelpersTests.testIncorrectAddr
 5/56 Test  #5: IpHelpersTests.testIncorrectAddr .....................   Passed    0.01 sec
      Start  6: CHHelpersTest.testMaglevCHSameWeight
 6/56 Test  #6: CHHelpersTest.testMaglevCHSameWeight .................   Passed    0.01 sec
      Start  7: CHHelpersTest.testMaglevV2CHSameWeight
 7/56 Test  #7: CHHelpersTest.testMaglevV2CHSameWeight ...............   Passed    0.01 sec
      Start  8: CHHelpersTest.testMaglevCHDiffWeight
 8/56 Test  #8: CHHelpersTest.testMaglevCHDiffWeight .................   Passed    0.01 sec
      Start  9: CHHelpersTest.testMaglevV2CHDiffWeight
 9/56 Test  #9: CHHelpersTest.testMaglevV2CHDiffWeight ...............   Passed    0.01 sec
      Start 10: CHHelpersTest.testMaglevWeightsSumLargerThanRing
10/56 Test #10: CHHelpersTest.testMaglevWeightsSumLargerThanRing .....   Passed    0.01 sec
      Start 11: CHHelpersTest.testMaglevWeightsSumBelowRingSize
11/56 Test #11: CHHelpersTest.testMaglevWeightsSumBelowRingSize ......   Passed    0.01 sec
      Start 12: KatranLbTest.testChangeMac
12/56 Test #12: KatranLbTest.testChangeMac ...........................   Passed    0.01 sec
      Start 13: KatranLbTest.testIfIndex
13/56 Test #13: KatranLbTest.testIfIndex .............................   Passed    0.01 sec
      Start 14: KatranLbTest.testVipHelpers
14/56 Test #14: KatranLbTest.testVipHelpers ..........................   Passed    0.14 sec
      Start 15: KatranLbTest.testAddingInvalidVip
15/56 Test #15: KatranLbTest.testAddingInvalidVip ....................   Passed    0.01 sec
      Start 16: KatranLbTest.testRealHelpers
16/56 Test #16: KatranLbTest.testRealHelpers .........................   Passed    0.01 sec
      Start 17: KatranLbTest.testRealFlags
17/56 Test #17: KatranLbTest.testRealFlags ...........................   Passed    0.01 sec
      Start 18: KatranLbTest.testVipStatsHelper
18/56 Test #18: KatranLbTest.testVipStatsHelper ......................   Passed    0.01 sec
      Start 19: KatranLbTest.testLruStatsHelper
19/56 Test #19: KatranLbTest.testLruStatsHelper ......................   Passed    0.01 sec
      Start 20: KatranLbTest.testLruMissStatsHelper
20/56 Test #20: KatranLbTest.testLruMissStatsHelper ..................   Passed    0.01 sec
      Start 21: KatranLbTest.testHcHelpers
21/56 Test #21: KatranLbTest.testHcHelpers ...........................   Passed    0.01 sec
      Start 22: KatranLbTest.getVipFlags
22/56 Test #22: KatranLbTest.getVipFlags .............................   Passed    0.01 sec
      Start 23: KatranLbTest.getAllVips
23/56 Test #23: KatranLbTest.getAllVips ..............................   Passed    0.01 sec
      Start 24: KatranLbTest.testUpdateRealsHelper
24/56 Test #24: KatranLbTest.testUpdateRealsHelper ...................   Passed    0.07 sec
      Start 25: KatranLbTest.testUpdateQuicRealsHelper
25/56 Test #25: KatranLbTest.testUpdateQuicRealsHelper ...............   Passed    0.06 sec
      Start 26: KatranLbTest.testUpdateQuicReal
26/56 Test #26: KatranLbTest.testUpdateQuicReal ......................   Passed    0.01 sec
      Start 27: KatranLbTest.getRealsForVip
27/56 Test #27: KatranLbTest.getRealsForVip ..........................   Passed    0.01 sec
      Start 28: KatranLbTest.getHealthcheckersDst
28/56 Test #28: KatranLbTest.getHealthcheckersDst ....................   Passed    0.01 sec
      Start 29: KatranLbTest.invalidAddressHandling
29/56 Test #29: KatranLbTest.invalidAddressHandling ..................   Passed    0.01 sec
      Start 30: KatranLbTest.addInvalidSrcRoutingRule
30/56 Test #30: KatranLbTest.addInvalidSrcRoutingRule ................   Passed    0.01 sec
      Start 31: KatranLbTest.addValidSrcRoutingRuleV4
31/56 Test #31: KatranLbTest.addValidSrcRoutingRuleV4 ................   Passed    0.01 sec
      Start 32: KatranLbTest.addValidSrcRoutingRuleV6
32/56 Test #32: KatranLbTest.addValidSrcRoutingRuleV6 ................   Passed    0.01 sec
      Start 33: KatranLbTest.addMaxSrcRules
33/56 Test #33: KatranLbTest.addMaxSrcRules ..........................   Passed    0.01 sec
      Start 34: KatranLbTest.delSrcRules
34/56 Test #34: KatranLbTest.delSrcRules .............................   Passed    0.01 sec
      Start 35: KatranLbTest.clearSrcRules
35/56 Test #35: KatranLbTest.clearSrcRules ...........................   Passed    0.01 sec
      Start 36: KatranLbTest.addFewInvalidNets
36/56 Test #36: KatranLbTest.addFewInvalidNets .......................   Passed    0.01 sec
      Start 37: KatranLbTest.addInvalidDecapDst
37/56 Test #37: KatranLbTest.addInvalidDecapDst ......................   Passed    0.01 sec
      Start 38: KatranLbTest.addInvalidDecapDstNet
38/56 Test #38: KatranLbTest.addInvalidDecapDstNet ...................   Passed    0.01 sec
      Start 39: KatranLbTest.addValidDecapDst
39/56 Test #39: KatranLbTest.addValidDecapDst ........................   Passed    0.01 sec
      Start 40: KatranLbTest.delValidDecapDst
40/56 Test #40: KatranLbTest.delValidDecapDst ........................   Passed    0.01 sec
      Start 41: KatranLbTest.delInvalidDecapDst
41/56 Test #41: KatranLbTest.delInvalidDecapDst ......................   Passed    0.01 sec
      Start 42: KatranLbTest.addMaxDecapDst
42/56 Test #42: KatranLbTest.addMaxDecapDst ..........................   Passed    0.01 sec
      Start 43: VipTestF.testBatchUpdateReals
43/56 Test #43: VipTestF.testBatchUpdateReals ........................   Passed    0.04 sec
      Start 44: VipTestF.testBatchUpdateRealsWeight
44/56 Test #44: VipTestF.testBatchUpdateRealsWeight ..................   Passed    0.05 sec
      Start 45: VipTestF.testGetRealsAndWeight
45/56 Test #45: VipTestF.testGetRealsAndWeight .......................   Passed    0.01 sec
      Start 46: VipTestF.testGetReals
46/56 Test #46: VipTestF.testGetReals ................................   Passed    0.02 sec
      Start 47: VipTest.testAddRemoveReal
47/56 Test #47: VipTest.testAddRemoveReal ............................   Passed    0.01 sec
      Start 48: EventPipeCallbackTest.SimpleCallbackTest
48/56 Test #48: EventPipeCallbackTest.SimpleCallbackTest .............   Passed    0.01 sec
      Start 49: EventPipeCallbackTest.LargeWriteTest
49/56 Test #49: EventPipeCallbackTest.LargeWriteTest .................   Passed    0.15 sec
      Start 50: TestMonitoringServiceCore.SimpleAcceptSubscription
50/56 Test #50: TestMonitoringServiceCore.SimpleAcceptSubscription ...   Passed    0.01 sec
      Start 51: TestMonitoringServiceCore.SimpleErrors
51/56 Test #51: TestMonitoringServiceCore.SimpleErrors ...............   Passed    0.01 sec
      Start 52: TestMonitoringServiceCore.EventIntersection
52/56 Test #52: TestMonitoringServiceCore.EventIntersection ..........   Passed    0.01 sec
      Start 53: TestMonitoringServiceCore.RacingClients
53/56 Test #53: TestMonitoringServiceCore.RacingClients ..............   Passed    0.01 sec
      Start 54: TestMonitoringServiceCore.SubscribeAndCancel
54/56 Test #54: TestMonitoringServiceCore.SubscribeAndCancel .........   Passed    0.01 sec
      Start 55: PcapWriterTest.SingleWriter
55/56 Test #55: PcapWriterTest.SingleWriter ..........................   Passed    0.02 sec
      Start 56: PcapWriterTest.MultiWriter
56/56 Test #56: PcapWriterTest.MultiWriter ...........................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 56

Total Test time (real) =   1.04 sec
+ cd ../testing/
+ ctest -v ./CMakeFiles ./CTestTestfile.cmake ./Makefile ./base64helpers-tests './base64helpers-tests[1]_include.cmake' './base64helpers-tests[1]_tests.cmake' ./cmake_install.cmake ./katran_tester ./libbase64_helpers.a ./libbpftester.a ./libkatran_test_provision.a ./libkatran_test_util.a ./libpcap_parser.a
ctest: /usr/local/lib/libcurl.so.4: no version information available (required by ctest)
Test project /home/ubuntu/ivanmorett/katran/_build/build/katran/lib/testing
    Start 1: Base64Tests.testEncode
1/2 Test #1: Base64Tests.testEncode ...........   Passed    0.01 sec
    Start 2: Base64Tests.testDecode
2/2 Test #2: Base64Tests.testDecode ...........   Passed    0.01 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.01 sec
+ popd
~/ivanmorett/katran/_build
```