### PR TITLE
[pck_parsing]: version.h is not used anymore

### DIFF
--- a/katran/lib/bpf/pckt_parsing.h
+++ b/katran/lib/bpf/pckt_parsing.h
@@ -30,7 +30,6 @@
 #include <linux/ptrace.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
-#include <linux/version.h>
 #include <stdbool.h>
 #include <stddef.h>
 


### PR DESCRIPTION
the check for kernel version was removed hence this file is not needed anymore


ps. seems like you folks have outdated CMake files. e.g. testing is missing UdpStableRtTestFixtures and XPopDecap