### PR TITLE
[testing]: fixing perf testing for packets w/ packet builder

### DIFF
--- a/katran/lib/testing/framework/BpfTester.cpp
+++ b/katran/lib/testing/framework/BpfTester.cpp
@@ -431,8 +431,15 @@ std::vector<TestResult> BpfTester::testPerfFromFixture(
 
   // Run all tests and collect results
   for (int i = first_index; i < last_index; i++) {
+    std::string input_packet;
+    if (config_.testData[i].inputPacketBuilder.has_value()) {
+      auto inputResult = config_.testData[i].inputPacketBuilder->build();
+      input_packet = inputResult.base64Packet;
+    } else {
+      input_packet = config_.testData[i].inputPacket;
+    }
     auto single_results = runXdpProgPerf(
-        config_.testData[i].inputPacket,
+        input_packet,
         config_.testData[i].description,
         repeat);
     results.insert(results.end(), single_results.begin(), single_results.end());
@@ -480,7 +487,7 @@ std::vector<TestResult> BpfTester::runXdpProgPerf(
       duration = 1;
     }
   }
-  if (repeat > 0) {
+  if (repeat > 0 && total_duration > 0) {
     auto avgDuration = total_duration / repeat;
     auto pps = kNanosecInSec / avgDuration;
     auto pps_millions = static_cast<double>(pps) / 1000000.0;

--- a/katran/lib/testing/framework/katran_tester.cpp
+++ b/katran/lib/testing/framework/katran_tester.cpp
@@ -398,7 +398,6 @@ int main(int argc, char** argv) {
     tester.testPcktsFromPcap();
     return 0;
   } else if (FLAGS_perf_testing) {
-    // for perf tests to work katran must be compiled w -DINLINE_DECAP
     preparePerfTestingLbData(*lb);
     auto results = tester.testPerfFromFixture(FLAGS_repeat, FLAGS_position);
     printPerfResults(results);


### PR DESCRIPTION
With some packets in textures moved to packet builder it broke perf testing. So fixing it. Also removing outdated comment about inline decap since you folks decided to run tons of syscalls instead 