### PR TITLE
Add shared BPF library at common/bpf/ and migrate 33 targets (#257)

### DIFF
--- a/katran/lib/bpf/balancer_consts.h
+++ b/katran/lib/bpf/balancer_consts.h
@@ -20,10 +20,7 @@
  * This file contains definition of all balancer specific constants
  */
 
-// we dont want to do htons for each packet, so this is ETH_P_IPV6 and
-// ETH_P_IP in be format
-#define BE_ETH_P_IP 8
-#define BE_ETH_P_IPV6 56710
+#include "common/bpf/bpf_net_helpers.h"
 
 // GUE variant 1 using first four bits of inner packet as a pseudo header
 // we are using last two of this four bits to distinct v4 vs v6. see RFC for


### PR DESCRIPTION
Summary:

Create a shared BPF library at common/bpf/ to consolidate duplicated network constants, IPv6 helpers, checksum routines, and packet parsing across BPF programs in fbcode.

Library headers:
- `bpf_net_helpers.h`: Network constants (`ETH_P_*`, `BE_ETH_P_*`), plus `IPPROTO_*`, `AF_*`, `TC_ACT_*` (guarded by `#ifdef __VMLINUX_H__` to avoid conflicting with `linux/in.h` enum definitions in traditional-header users), IPv6 address comparison (`ipv6_addr_equal`, `ipv6_addr_prefix_match`), and packet parsing primitives (`bpf_parse_eth`, `bpf_parse_ipv6`). The `bpf_parse_*` functions are minimal building blocks: bounds-check and return a typed pointer, composable with any higher-level parsing pattern.
- `bpf_csum.h`: Checksum fold/add/sub, IPv4 csum, IPv6 pseudo-header, RFC 1624 incremental, L4 checksum offset lookup.

For byte-order conversions, the library uses `bpf_htons`/`bpf_ntohs`/`bpf_htonl`/`bpf_ntohl` from `<bpf/bpf_endian.h>` instead of rolling its own.

Migrated 33 build targets across 15 projects:
- tee/cvm_xdp: parsing + csum + ipv6 helpers (removed dead csum.h)
- ti/edgetee: `BE_ETH_P_*` constants
- ti/edge_host_routing (mpls): `ipv6_addr_equal` + `ipv4_csum`
- ti/xdpdump: `BE_ETH_P_*` constants (4 targets)
- ti/droplet: `BE_ETH_P_*` and other overlapping constants from kernel_helpers.h
- neteng/urgd: inlined counter helper back (removed bpf_stats.h)
- neteng/netedit (nat64): `csum_l4_offset` + `ipv6_pseudohdr_checksum` directly at call sites
- neteng/netedit (gcp_netslo_steering): `ipv6_addr_equal` + `bpf_parse_eth`/`bpf_parse_ipv6` directly at call sites (removed thin wrapper functions)
- neteng/ilarouter: `csum_fold` directly at call sites
- metaverse/myelin (iprewrite, nat464): csum + ipv6 helpers
- katran (balancer, healthchecking, kde, edgeloom): `BE_ETH_P_*` constants via balancer_consts.h
- kernel/rx_steering: `BE_ETH_P_IPV6` constant
- common/services/cpp (takeover): `BE_ETH_P_*` constants
- remote_execution (lo_filter): `BE_ETH_P_*` constants
- sslwall: `csum_fold` directly at call sites
- tupperware (ttls NAT464, agent/net/decapsulation tc_decap): `csum_l4_offset` directly at call sites + transitive dep via balancer_consts.h

Reviewed By: zuxy

Differential Revision: D99357415


