### PR TITLE
fix: remove trailing colon from MAC address string

### DIFF
--- a/katran/lib/MacHelpers.cpp
+++ b/katran/lib/MacHelpers.cpp
@@ -52,7 +52,7 @@ std::string convertMacToString(std::vector<uint8_t> mac) {
     mac_part_string = fmt::format("{0:02x}:", mac_part);
     mac_string += mac_part_string;
   }
-  return mac_string;
+  return mac_string.substr(0, mac_string.size() - 1);
 }
 
 } // namespace katran


### PR DESCRIPTION
Closes #258 

Fixed `convertMacToString` in `katran/lib/MacHelpers.cpp` to strip the trailing colon from the formatted MAC address string by using `substr` to drop the last character before returning.

Fix applied is: (as mentioned in #258 )

```sh
return mac_string.substr(0, mac_string.size() - 1);
```